### PR TITLE
Debug long startup w/ many keys

### DIFF
--- a/benches/storage_benchmark.rs
+++ b/benches/storage_benchmark.rs
@@ -132,6 +132,7 @@ fn benchmark_random_reads(path: &PathBuf) {
         let key = format!("bench-key-{i}");
         let handle = storage
             .read(key.as_bytes())
+            .unwrap()
             .expect("Missing entry in random read");
 
         let stored = u64::from_le_bytes(handle.as_slice().try_into().unwrap());

--- a/experiments/simd-r-drive-ws-client/src/ws_client.rs
+++ b/experiments/simd-r-drive-ws-client/src/ws_client.rs
@@ -85,6 +85,10 @@ impl AsyncDataStoreReader for WsClient {
         Ok(resp.result)
     }
 
+    async fn read_last_entry(&self) -> Result<Option<Self::EntryHandleType>> {
+        unimplemented!("`read_last_entry` is not currently implemented");
+    }
+
     async fn batch_read(&self, keys: &[&[u8]]) -> Result<Vec<Option<Self::EntryHandleType>>> {
         let batch_read_result = BatchRead::call(
             &self.rpc_client,

--- a/experiments/simd-r-drive-ws-server/src/main.rs
+++ b/experiments/simd-r-drive-ws-server/src/main.rs
@@ -123,8 +123,8 @@ async fn main() -> std::io::Result<()> {
                         // and then drop the read lock to maximize concurrency.
                         let store = store_mutex.blocking_read();
                         let result_data = store
-                            .read(&req.key)
-                            .map(|handle| handle.as_slice().to_vec()); // TODO: Apply error handling
+                            .read(&req.key)?
+                            .map(|handle| handle.as_slice().to_vec());
                         let resp = Read::encode_response(ReadResponseParams {
                             result: result_data,
                         })?;

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -160,6 +160,7 @@ storage
 // Read from storage stream
 let mut stored_stream = storage
     .open_file_stream(relative_file, Some(b"some-namespace"))
+    .unwrap()
     .expect("File not found in storage");
 
 let mut stored_contents = String::new();
@@ -209,6 +210,7 @@ storage
 // Read from storage
 let mut stored = storage
     .open_file_stream(relative_file, Some(b"some-namespace"))
+    .unwrap()
     .expect("File not found in storage");
 
 let mut stored_contents = String::new();

--- a/extensions/src/storage_cache_ext.rs
+++ b/extensions/src/storage_cache_ext.rs
@@ -83,7 +83,7 @@ impl StorageCacheExt for DataStore {
             TTL_NAMESPACE_HASHER.get_or_init(|| Arc::new(NamespaceHasher::new(TTL_PREFIX)));
         let namespaced_key = namespace_hasher.namespace(key);
 
-        match self.read(&namespaced_key) {
+        match self.read(&namespaced_key)? {
             Some(entry) => {
                 let data = entry.as_slice();
 

--- a/extensions/src/storage_cache_ext.rs
+++ b/extensions/src/storage_cache_ext.rs
@@ -6,7 +6,7 @@ use simd_r_drive::{
     traits::{DataStoreReader, DataStoreWriter},
     utils::NamespaceHasher,
 };
-use std::io::{self, ErrorKind};
+use std::io::{self, ErrorKind, Result};
 use std::sync::{Arc, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -35,8 +35,7 @@ pub trait StorageCacheExt {
     /// ## Returns
     /// - `Ok(offset)`: The **file offset** where the data was written.
     /// - `Err(std::io::Error)`: If the write operation fails.
-    fn write_with_ttl<T: Serialize>(&self, key: &[u8], value: &T, ttl_secs: u64)
-    -> io::Result<u64>;
+    fn write_with_ttl<T: Serialize>(&self, key: &[u8], value: &T, ttl_secs: u64) -> Result<u64>;
 
     /// Reads a value, checking TTL expiration.
     ///
@@ -49,7 +48,7 @@ pub trait StorageCacheExt {
     /// - `Ok(Some(T))`: If the TTL is still valid and the value is readable.
     /// - `Ok(None)`: If the TTL has expired and the entry has been evicted.
     /// - `Err(std::io::Error)`: If the key is missing or deserialization fails.
-    fn read_with_ttl<T: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<T>, io::Error>;
+    fn read_with_ttl<T: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<T>>;
 }
 
 /// Implements TTL-based caching for `DataStore`
@@ -78,7 +77,7 @@ impl StorageCacheExt for DataStore {
         self.write(&namespaced_key, &data)
     }
 
-    fn read_with_ttl<T: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<T>, io::Error> {
+    fn read_with_ttl<T: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<T>> {
         let namespace_hasher =
             TTL_NAMESPACE_HASHER.get_or_init(|| Arc::new(NamespaceHasher::new(TTL_PREFIX)));
         let namespaced_key = namespace_hasher.namespace(key);

--- a/extensions/src/storage_file_import_ext.rs
+++ b/extensions/src/storage_file_import_ext.rs
@@ -114,7 +114,6 @@ impl StorageFileImportExt for DataStore {
     }
 }
 
-// TODO: Move to utils
 fn to_namespaced_key<P: AsRef<Path>>(rel_path: P, namespace: Option<&[u8]>) -> Vec<u8> {
     let unix_key = rel_path
         .as_ref()

--- a/extensions/src/storage_file_import_ext.rs
+++ b/extensions/src/storage_file_import_ext.rs
@@ -100,6 +100,7 @@ impl StorageFileImportExt for DataStore {
         Ok(results)
     }
 
+    // TODO: Use `Result` type
     fn read_file_entry<P: AsRef<Path>>(
         &self,
         rel_path: P,
@@ -109,6 +110,7 @@ impl StorageFileImportExt for DataStore {
         self.read(&namespaced_key)
     }
 
+    // TODO: Use `Result` type
     fn open_file_stream<P: AsRef<Path>>(
         &self,
         rel_path: P,

--- a/extensions/src/storage_file_import_ext.rs
+++ b/extensions/src/storage_file_import_ext.rs
@@ -4,25 +4,18 @@ use simd_r_drive::{
     utils::NamespaceHasher,
 };
 use std::fs::File;
-use std::io::{self};
+use std::io::{self, Result};
 use std::path::Path;
 
 /// Recursively walks a directory and imports files into the DataStore.
 /// Keys are the relative Unix-style paths from `base_dir`.
 pub trait StorageFileImportExt {
     /// Adds all regular files under `base_dir` into the DataStore.
-    ///
-    /// # Arguments
-    /// - `base_dir`: Root directory to walk.
-    /// - `namespace`: Optional namespace prefix for stored keys.
-    ///
-    /// # Returns
-    /// - A list of `(key, offset)` for stored files.
     fn import_dir_recursively<P: AsRef<Path>>(
         &self,
         base_dir: P,
         namespace: Option<&[u8]>,
-    ) -> io::Result<Vec<(Vec<u8>, u64)>>;
+    ) -> Result<Vec<(Vec<u8>, u64)>>;
 
     /// Retrieves a file entry **stored in the DataStore**, using a relative path
     /// and optional namespace.
@@ -35,13 +28,14 @@ pub trait StorageFileImportExt {
     /// - `namespace`: Optional namespace used during import (if any).
     ///
     /// # Returns
-    /// - `Some(EntryHandle)`: If the file exists in storage.
-    /// - `None`: If the key is missing or marked deleted.
+    /// - `Ok(Some(EntryHandle))`: If the file exists in storage.
+    /// - `Ok(None)`: If the key is missing or marked deleted.
+    /// - `Err`: If there is an I/O error.
     fn read_file_entry<P: AsRef<Path>>(
         &self,
         rel_path: P,
         namespace: Option<&[u8]>,
-    ) -> Option<EntryHandle>;
+    ) -> Result<Option<EntryHandle>>;
 
     /// Opens a **streaming reader** for a file stored in the DataStore,
     /// identified by its relative path and optional namespace.
@@ -54,13 +48,14 @@ pub trait StorageFileImportExt {
     /// - `namespace`: Optional namespace prefix applied during import.
     ///
     /// # Returns
-    /// - `Some(EntryStream)`: If the file exists in storage.
-    /// - `None`: If no entry is found or it has been evicted.
+    /// - `Ok(Some(EntryStream))`: If the file exists in storage.
+    /// - `Ok(None)`: If no entry is found or it has been evicted.
+    /// - `Err`: If there is an I/O error.
     fn open_file_stream<P: AsRef<Path>>(
         &self,
         rel_path: P,
         namespace: Option<&[u8]>,
-    ) -> Option<EntryStream>;
+    ) -> Result<Option<EntryStream>>;
 }
 
 impl StorageFileImportExt for DataStore {
@@ -68,7 +63,7 @@ impl StorageFileImportExt for DataStore {
         &self,
         base_dir: P,
         namespace: Option<&[u8]>,
-    ) -> io::Result<Vec<(Vec<u8>, u64)>> {
+    ) -> Result<Vec<(Vec<u8>, u64)>> {
         let mut results = Vec::new();
         let base = base_dir.as_ref();
 
@@ -81,7 +76,7 @@ impl StorageFileImportExt for DataStore {
 
         for entry in walkdir::WalkDir::new(base)
             .into_iter()
-            .filter_map(Result::ok)
+            .filter_map(|result| result.ok())
         {
             let path = entry.path();
             if !path.is_file() {
@@ -100,27 +95,26 @@ impl StorageFileImportExt for DataStore {
         Ok(results)
     }
 
-    // TODO: Use `Result` type
     fn read_file_entry<P: AsRef<Path>>(
         &self,
         rel_path: P,
         namespace: Option<&[u8]>,
-    ) -> Option<EntryHandle> {
+    ) -> Result<Option<EntryHandle>> {
         let namespaced_key = to_namespaced_key(rel_path, namespace);
         self.read(&namespaced_key)
     }
 
-    // TODO: Use `Result` type
     fn open_file_stream<P: AsRef<Path>>(
         &self,
         rel_path: P,
         namespace: Option<&[u8]>,
-    ) -> Option<EntryStream> {
+    ) -> Result<Option<EntryStream>> {
         let namespaced_key = to_namespaced_key(rel_path, namespace);
-        self.read(&namespaced_key).map(EntryStream::from)
+        Ok(self.read(&namespaced_key)?.map(EntryStream::from))
     }
 }
 
+// TODO: Move to utils
 fn to_namespaced_key<P: AsRef<Path>>(rel_path: P, namespace: Option<&[u8]>) -> Vec<u8> {
     let unix_key = rel_path
         .as_ref()

--- a/extensions/src/storage_option_ext.rs
+++ b/extensions/src/storage_option_ext.rs
@@ -155,7 +155,7 @@ impl StorageOptionExt for DataStore {
             OPTION_NAMESPACE_HASHER.get_or_init(|| Arc::new(NamespaceHasher::new(OPTION_PREFIX)));
         let namespaced_key = namespace_hasher.namespace(key);
 
-        match self.read(&namespaced_key) {
+        match self.read(&namespaced_key)? {
             Some(entry) => deserialize_option::<T>(entry.as_slice()),
             None => Err(io::Error::new(
                 ErrorKind::NotFound,

--- a/extensions/tests/storage_cache_tests.rs
+++ b/extensions/tests/storage_cache_tests.rs
@@ -277,14 +277,14 @@ fn test_ttl_prefix_is_applied() {
         .expect("Failed to write with TTL");
 
     // Ensure the prefixed key exists in storage
-    let raw_data = storage.read(&namespaced_key);
+    let raw_data = storage.read(&namespaced_key).unwrap();
     assert!(
         raw_data.is_some(),
         "Expected data to be stored under the prefixed key"
     );
 
     // Ensure the unprefixed key does not exist
-    let raw_data_unprefixed = storage.read(key);
+    let raw_data_unprefixed = storage.read(key).unwrap();
     assert!(
         raw_data_unprefixed.is_none(),
         "Unprefixed key should not exist in storage"
@@ -321,13 +321,13 @@ fn test_ttl_prefixing_does_not_affect_regular_storage() {
 
     // Ensure reading from TTL-prefixed key fails (since it was not stored with TTL)
     let namespaced_key = namespace_hasher.namespace(key);
-    let raw_data_prefixed = storage.read(&namespaced_key);
+    let raw_data_prefixed = storage.read(&namespaced_key).unwrap();
     assert!(
         raw_data_prefixed.is_none(),
         "No TTL-prefixed entry should exist for a non-TTL write"
     );
 
     // Ensure we can still retrieve the non-TTL stored value
-    let retrieved: TestData = bincode::deserialize(&storage.read(key).unwrap()).unwrap();
+    let retrieved: TestData = bincode::deserialize(&storage.read(key).unwrap().unwrap()).unwrap();
     assert_eq!(retrieved, test_value, "Non-TTL value should be retrievable");
 }

--- a/extensions/tests/storage_file_import_tests.rs
+++ b/extensions/tests/storage_file_import_tests.rs
@@ -53,7 +53,7 @@ fn test_import_directory_and_verify_contents() {
         file.read_to_end(&mut expected)
             .expect("Failed to read file");
 
-        let actual = storage.read(&key).expect("Key missing from store");
+        let actual = storage.read(&key).unwrap().expect("Key missing from store");
         assert_eq!(
             actual.as_slice(),
             expected.as_slice(),
@@ -91,7 +91,7 @@ fn test_import_without_namespace() {
             .read_to_end(&mut expected)
             .expect("Failed to read file");
 
-        let stored = storage.read(key).expect("Missing key in store");
+        let stored = storage.read(key).unwrap().expect("Missing key in store");
         assert_eq!(stored.as_slice(), expected.as_slice());
     }
 }
@@ -119,6 +119,7 @@ fn test_read_file_entry_returns_correct_contents() {
 
     let entry = storage
         .read_file_entry(&known_file, None)
+        .unwrap()
         .expect("Expected file entry to be present");
 
     let mut expected = Vec::new();
@@ -153,6 +154,7 @@ fn test_open_file_stream_reads_all_bytes() {
 
     let mut stream = storage
         .open_file_stream(&known_file, None)
+        .unwrap()
         .expect("Expected file stream to be present");
 
     let mut streamed = Vec::new();

--- a/extensions/tests/storage_option_tests.rs
+++ b/extensions/tests/storage_option_tests.rs
@@ -114,7 +114,7 @@ mod tests {
         let namespaced_key = namespace_hasher.namespace(key);
 
         // Step 4: Ensure the entry still exists in storage (not fully deleted)
-        let raw_entry = storage.read(&namespaced_key);
+        let raw_entry = storage.read(&namespaced_key).unwrap();
         assert!(
             raw_entry.is_some(),
             "Entry should still exist in storage even after writing None"
@@ -241,14 +241,14 @@ mod tests {
             .expect("Failed to write option");
 
         // Ensure the prefixed key exists in storage
-        let raw_data = storage.read(&namespaced_key);
+        let raw_data = storage.read(&namespaced_key).unwrap();
         assert!(
             raw_data.is_some(),
             "Expected data to be stored under the prefixed key"
         );
 
         // Ensure the unprefixed key does not exist
-        let raw_data_unprefixed = storage.read(key);
+        let raw_data_unprefixed = storage.read(key).unwrap();
         assert!(
             raw_data_unprefixed.is_none(),
             "Unprefixed key should not exist in storage"
@@ -280,14 +280,14 @@ mod tests {
             .expect("Failed to write None with option handling");
 
         // Ensure the prefixed key exists in storage (tombstone marker stored)
-        let raw_data = storage.read(&namespaced_key);
+        let raw_data = storage.read(&namespaced_key).unwrap();
         assert!(
             raw_data.is_some(),
             "Expected tombstone marker to be stored under the prefixed key"
         );
 
         // Ensure the unprefixed key does not exist
-        let raw_data_unprefixed = storage.read(key);
+        let raw_data_unprefixed = storage.read(key).unwrap();
         assert!(
             raw_data_unprefixed.is_none(),
             "Unprefixed key should not exist in storage"
@@ -323,14 +323,17 @@ mod tests {
 
         // Ensure reading from the option-prefixed key fails (since it was not stored as an option)
         let namespaced_key = namespace_hasher.namespace(key);
-        let raw_data_prefixed = storage.read(&namespaced_key);
+        let raw_data_prefixed = storage.read(&namespaced_key).unwrap();
         assert!(
             raw_data_prefixed.is_none(),
             "No option-prefixed entry should exist for a non-prefixed write"
         );
 
         // Ensure we can still retrieve the non-prefixed stored value
-        let raw_bytes = storage.read(key).expect("Failed to read stored data");
+        let raw_bytes = storage
+            .read(key)
+            .unwrap()
+            .expect("Failed to read stored data");
         let retrieved: TestData =
             bincode::deserialize(&raw_bytes).expect("Failed to deserialize TestData");
         assert_eq!(

--- a/src/cli/execute_command.rs
+++ b/src/cli/execute_command.rs
@@ -40,7 +40,7 @@ pub fn execute_command(cli: &Cli) {
                 .unwrap_or(64 * 1024); // Default to 64KB
 
             match storage.read(key.as_bytes()) {
-                Some(entry_handle) => {
+                Ok(Some(entry_handle)) => {
                     let stdout = io::stdout();
                     let mut stdout_handle = stdout.lock();
                     let mut entry_stream = EntryStream::from(entry_handle);
@@ -74,8 +74,12 @@ pub fn execute_command(cli: &Cli) {
                         stdout_handle.write_all(b"\n").unwrap();
                     }
                 }
-                None => {
+                Ok(None) => {
                     eprintln!("Error: Key '{}' not found", key);
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    error!("Error: {:?}", e);
                     std::process::exit(1);
                 }
             }
@@ -185,7 +189,7 @@ pub fn execute_command(cli: &Cli) {
             let storage = DataStore::open_existing(&cli.storage).expect("Failed to open storage");
 
             match storage.read(key.as_bytes()) {
-                Some(entry) => {
+                Ok(Some(entry)) => {
                     println!("\n{:=^50}", " METADATA SUMMARY ");
                     println!("{:<25} \"{}\"", "ENTRY FOR:", key);
                     println!("{:-<50}", ""); // Separator
@@ -215,8 +219,12 @@ pub fn execute_command(cli: &Cli) {
                     println!("{:<25} {:?}", "STORED METADATA:", entry.metadata());
                     println!("{:=<50}", ""); // Footer Line
                 }
-                None => {
+                Ok(None) => {
                     error!("Error: Key '{}' not found", key);
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    error!("Error: {:?}", e);
                     std::process::exit(1);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,30 +36,30 @@
 //! storage.write(b"key5", b"value5").unwrap();
 //!
 //! // Retrieve some entries
-//! let entry = storage.read(b"key1").unwrap();
-//! assert_eq!(entry.as_slice(), b"value1");
+//! let entry_handle = storage.read(b"key1").unwrap().unwrap();
+//! assert_eq!(entry_handle.as_slice(), b"value1");
 //!
-//! let entry = storage.read(b"key2").unwrap();
-//! assert_eq!(entry.as_slice(), b"value2");
+//! let entry_handle = storage.read(b"key2").unwrap().unwrap();
+//! assert_eq!(entry_handle.as_slice(), b"value2");
 //!
-//! let entry = storage.read(b"key3").unwrap();
-//! assert_eq!(entry.as_slice(), b"value3");
+//! let entry_handle = storage.read(b"key3").unwrap().unwrap();
+//! assert_eq!(entry_handle.as_slice(), b"value3");
 //!
-//! let entry = storage.read(b"key4").unwrap();
-//! assert_eq!(entry.as_slice(), b"value4");
+//! let entry_handle = storage.read(b"key4").unwrap().unwrap();
+//! assert_eq!(entry_handle.as_slice(), b"value4");
 //!
-//! let entry = storage.read(b"key5").unwrap();
-//! assert_eq!(entry.as_slice(), b"value5");
+//! let entry_handle = storage.read(b"key5").unwrap().unwrap();
+//! assert_eq!(entry_handle.as_slice(), b"value5");
 //!
 //! // Overwrite an entry
 //! storage.write(b"key3", b"A new value").unwrap();
-//! let entry = storage.read(b"key3").unwrap();
-//! assert_eq!(entry.as_slice(), b"A new value");
+//! let entry_handle = storage.read(b"key3").unwrap().unwrap();
+//! assert_eq!(entry_handle.as_slice(), b"A new value");
 //!
 //! // Delete an entry
 //! storage.delete_entry(b"key3").unwrap();
-//! let entry = storage.read(b"key3");
-//! assert!(entry.is_none());
+//! let entry_handle = storage.read(b"key3").unwrap();
+//! assert!(entry_handle.is_none());
 //! ```
 //!
 //! ## Streaming Example
@@ -84,7 +84,7 @@
 //! storage.write_stream(b"stream_key", &mut cursor).unwrap();
 //!
 //! // Read and validate streaming data using `EntryStream`
-//! let entry_handle = storage.read(b"stream_key").unwrap(); // Get EntryHandle
+//! let entry_handle = storage.read(b"stream_key").unwrap().unwrap(); // Get EntryHandle
 //! let mut retrieved_stream = EntryStream::from(entry_handle); // Convert to EntryStream
 //! let mut buffer = Vec::new();
 //!
@@ -102,7 +102,7 @@
 //! storage.write_stream(b"file_stream_key", &mut file).unwrap();
 //!
 //! // Read back the streamed file using `EntryStream`
-//! let file_entry = storage.read(b"file_stream_key").unwrap(); // Get EntryHandle
+//! let file_entry = storage.read(b"file_stream_key").unwrap().unwrap(); // Get EntryHandle
 //! let mut file_stream = EntryStream::from(file_entry); // Convert to EntryStream
 //! let mut file_buffer = Vec::new();
 //!

--- a/src/storage_engine.rs
+++ b/src/storage_engine.rs
@@ -2,22 +2,22 @@ mod constants;
 use constants::*;
 
 mod data_store;
-pub use data_store::DataStore;
+pub use data_store::*;
 
 mod entry_handle;
-pub use entry_handle::EntryHandle;
+pub use entry_handle::*;
 
 mod entry_iterator;
-pub use entry_iterator::EntryIterator;
+pub use entry_iterator::*;
 
 mod entry_metadata;
-pub use entry_metadata::EntryMetadata;
+pub use entry_metadata::*;
 
 mod entry_stream;
-pub use entry_stream::EntryStream;
+pub use entry_stream::*;
 
 mod key_indexer;
-pub use key_indexer::KeyIndexer;
+pub use key_indexer::*;
 
 pub mod digest;
 
@@ -25,3 +25,9 @@ mod simd_copy;
 use simd_copy::*;
 
 pub mod traits;
+
+pub mod static_hash_index;
+pub use static_hash_index::*;
+
+pub mod index_layer;
+pub use index_layer::*;

--- a/src/storage_engine/data_store.rs
+++ b/src/storage_engine/data_store.rs
@@ -3,6 +3,7 @@ use crate::storage_engine::digest::{
     Xxh3BuildHasher, compute_checksum, compute_hash, compute_hash_batch,
 };
 use crate::storage_engine::simd_copy;
+use crate::storage_engine::static_hash_index::flush_static_index;
 use crate::storage_engine::{EntryHandle, EntryIterator, EntryMetadata, EntryStream, KeyIndexer};
 use crate::traits::{DataStoreReader, DataStoreWriter};
 use crate::utils::verify_file_existence;
@@ -13,31 +14,15 @@ use std::convert::From;
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-
-// Experimented with using a feature flag to enable `tokio::sync::Mutex`
-// and `tokio::sync::RwLock` for async compatibility but decided to hold off for now.
-// The current implementation remains on `std::sync::{Mutex, RwLock}` because:
-// - The existing code is **blocking**, and there is no immediate need for async locks.
-// - Switching to `tokio::sync` would require `.await` at locking points, leading
-//   to refactoring without clear performance benefits at this stage.
-// - Lock contention has not yet been identified as a bottleneck, so there's no
-//   strong reason to introduce async synchronization primitives.
-// This decision may be revisited if future profiling shows tangible benefits.
-use std::sync::{
-    Arc,
-    Mutex,
-    // TODO: Investigate using `parking_lot::RwLock;`
-    RwLock,
-};
-
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 
 /// Append-Only Storage Engine
 pub struct DataStore {
     file: Arc<RwLock<BufWriter<File>>>,
     mmap: Arc<Mutex<Arc<Mmap>>>,
     tail_offset: AtomicU64,
-    key_indexer: Arc<RwLock<KeyIndexer>>,
+    key_indexer: Arc<RwLock<KeyIndexer<'static>>>,
     path: PathBuf,
 }
 
@@ -51,125 +36,32 @@ impl IntoIterator for DataStore {
 }
 
 impl From<PathBuf> for DataStore {
-    /// Creates an `DataStore` instance from a `PathBuf`.
-    ///
-    /// This allows creating a storage instance **directly from a file path**.
-    ///
-    /// # Panics:
-    /// - If the file cannot be opened or mapped into memory.
     fn from(path: PathBuf) -> Self {
         DataStore::open(&path).expect("Failed to open storage file")
     }
 }
 
 impl DataStoreWriter for DataStore {
-    /// Writes an entry using a streaming `Read` source (e.g., file, network).
-    ///
-    /// This method is designed for **large entries** that may exceed available RAM,
-    /// allowing them to be written in chunks without loading the full payload into memory.
-    ///
-    /// # Parameters:
-    /// - `key`: The **binary key** for the entry.
-    /// - `reader`: A **streaming reader** (`Read` trait) supplying the entry's content.
-    ///
-    /// # Returns:
-    /// - `Ok(offset)`: The file offset where the entry was written.
-    /// - `Err(std::io::Error)`: If a write or I/O operation fails.
-    ///
-    /// # Notes:
-    /// - Internally, this method delegates to `write_stream_with_key_hash`, computing
-    ///   the key hash first.
-    /// - If the entry is **small enough to fit in memory**, consider using `write()`
-    ///   or `batch_write()` instead if you don't want to stream the data in.
-    ///
-    /// # Streaming Behavior:
-    /// - The `reader` is **read incrementally in 64KB chunks** (`WRITE_STREAM_BUFFER_SIZE`).
-    /// - Data is immediately **written to disk** as it is read.
-    /// - **A checksum is computed incrementally** during the write.
-    /// - Metadata is appended **after** the full entry is written.
     fn write_stream<R: Read>(&self, key: &[u8], reader: &mut R) -> Result<u64> {
         let key_hash = compute_hash(key);
         self.write_stream_with_key_hash(key_hash, reader)
     }
 
-    /// Writes an entry with a given key and payload.
-    ///
-    /// This method computes the hash of the key and delegates to `write_with_key_hash()`.
-    /// It is a **high-level API** for adding new entries to the storage.
-    ///
-    /// # Parameters:
-    /// - `key`: The **binary key** associated with the entry.
-    /// - `payload`: The **data payload** to be stored.
-    ///
-    /// # Returns:
-    /// - `Ok(offset)`: The file offset where the entry was written.
-    /// - `Err(std::io::Error)`: If a write operation fails.
-    ///
-    /// # Notes:
-    /// - If you need streaming support, use `write_stream` instead.
-    /// - If multiple entries with the **same key** are written, the most recent
-    ///   entry will be retrieved when reading.
-    /// - This method **locks the file for writing** to ensure consistency.
-    /// - For writing **multiple entries at once**, use `batch_write()`.
     fn write(&self, key: &[u8], payload: &[u8]) -> Result<u64> {
         let key_hash = compute_hash(key);
         self.write_with_key_hash(key_hash, payload)
     }
 
-    /// Writes multiple key-value pairs as a **single transaction**.
-    ///
-    /// This method computes the hashes of the provided keys and delegates to
-    /// `batch_write_hashed_payloads()`, ensuring all writes occur in a single
-    /// locked operation for efficiency.
-    ///
-    /// # Parameters:
-    /// - `entries`: A **slice of key-value pairs**, where:
-    ///   - `key`: The **binary key** for the entry.
-    ///   - `payload`: The **data payload** to be stored.
-    ///
-    /// # Returns:
-    /// - `Ok(final_offset)`: The file offset after all writes.
-    /// - `Err(std::io::Error)`: If a write operation fails.
-    ///
-    /// # Notes:
-    /// - This method improves efficiency by **minimizing file lock contention**.
-    /// - If a large number of entries are written, **batching reduces overhead**.
-    /// - If the key hashes are already computed, use `batch_write_hashed_payloads()`.
     fn batch_write(&self, entries: &[(&[u8], &[u8])]) -> Result<u64> {
-        // 1.  Split keys & payloads so we can hash the keys in one go.
         let (keys, payloads): (Vec<_>, Vec<_>) = entries.iter().cloned().unzip();
-
-        // 2.  One call → many hashes (stays outside the write-lock).
         let hashes = compute_hash_batch(&keys);
-
-        // 3.  Zip hashes back with payloads and hand off to the low-level routine.
         let hashed_entries = hashes
             .into_iter()
             .zip(payloads.into_iter())
             .collect::<Vec<_>>();
-
         self.batch_write_hashed_payloads(hashed_entries, false)
     }
 
-    /// Renames an existing entry by copying it under a new key and marking the old key as deleted.
-    ///
-    /// This function:
-    /// - Reads the existing entry associated with `old_key`.
-    /// - Writes the same data under `new_key`.
-    /// - Deletes the `old_key` by appending a tombstone entry.
-    ///
-    /// # Parameters:
-    /// - `old_key`: The **original key** of the entry to be renamed.
-    /// - `new_key`: The **new key** under which the entry will be stored.
-    ///
-    /// # Returns:
-    /// - `Ok(new_offset)`: The file offset where the new entry was written.
-    /// - `Err(std::io::Error)`: If the old key is not found or if a write operation fails.
-    ///
-    /// # Notes:
-    /// - This operation **does not modify** the original entry but instead appends a new copy.
-    /// - The old key is **logically deleted** via an append-only tombstone.
-    /// - Attempting to rename a key to itself will return an error.
     fn rename_entry(&self, old_key: &[u8], new_key: &[u8]) -> Result<u64> {
         if old_key == new_key {
             return Err(std::io::Error::new(
@@ -181,34 +73,14 @@ impl DataStoreWriter for DataStore {
         let old_entry = self.read(old_key).ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::NotFound, "Old key not found")
         })?;
-
         let mut old_entry_stream = EntryStream::from(old_entry);
 
         self.write_stream(new_key, &mut old_entry_stream)?;
 
         let new_offset = self.delete_entry(old_key)?;
-
         Ok(new_offset)
     }
 
-    /// Copies an entry to a **different storage container**.
-    ///
-    /// This function:
-    /// - Reads the entry associated with `key` in the current storage.
-    /// - Writes it to the `target` storage.
-    ///
-    /// # Parameters:
-    /// - `key`: The **key** of the entry to be copied.
-    /// - `target`: The **destination storage** where the entry should be copied.
-    ///
-    /// # Returns:
-    /// - `Ok(target_offset)`: The file offset where the copied entry was written in the target storage.
-    /// - `Err(std::io::Error)`: If the key is not found, if the write operation fails,  
-    ///   or if attempting to copy to the same storage.
-    ///
-    /// # Notes:
-    /// - Copying within the **same** storage is unnecessary; use `rename_entry` instead.
-    /// - This operation does **not** delete the original entry.
     fn copy_entry(&self, key: &[u8], target: &DataStore) -> Result<u64> {
         if self.path == target.path {
             return Err(std::io::Error::new(
@@ -223,47 +95,17 @@ impl DataStoreWriter for DataStore {
         let entry_handle = self.read(key).ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("Key not found: {:?}", key),
+                format!("Key not found: {:?}", String::from_utf8_lossy(key)),
             )
         })?;
-
         self.copy_entry_handle(&entry_handle, target)
     }
 
-    /// Moves an entry from the current storage to a **different storage container**.
-    ///
-    /// This function:
-    /// - Copies the entry from the current storage to `target`.
-    /// - Marks the original entry as deleted.
-    ///
-    /// # Parameters:
-    /// - `key`: The **key** of the entry to be moved.
-    /// - `target`: The **destination storage** where the entry should be moved.
-    ///
-    /// # Returns:
-    /// - `Ok(target_offset)`: The file offset where the entry was written in the target storage.
-    /// - `Err(std::io::Error)`: If the key is not found, or if the copy/delete operation fails.
-    ///
-    /// # Notes:
-    /// - Moving an entry within the **same** storage is unnecessary; use `rename_entry` instead.
-    /// - The original entry is **logically deleted** by appending a tombstone, maintaining
-    ///   the append-only structure.
     fn move_entry(&self, key: &[u8], target: &DataStore) -> Result<u64> {
         self.copy_entry(key, target)?;
-
         self.delete_entry(key)
     }
 
-    /// Deletes a key by appending a **null byte marker**.
-    ///
-    /// The storage engine is **append-only**, so keys cannot be removed directly.
-    /// Instead, a **null byte is appended** as a tombstone entry to mark the key as deleted.
-    ///
-    /// # Parameters:
-    /// - `key`: The **binary key** to mark as deleted.
-    ///
-    /// # Returns:
-    /// - The **new file offset** where the delete marker was appended.
     fn delete_entry(&self, key: &[u8]) -> Result<u64> {
         let key_hash = compute_hash(key);
         self.batch_write_hashed_payloads(vec![(key_hash, &NULL_BYTE)], true)
@@ -273,20 +115,6 @@ impl DataStoreWriter for DataStore {
 impl DataStoreReader for DataStore {
     type EntryHandleType = EntryHandle;
 
-    /// Retrieves the most recent value associated with a given key.
-    ///
-    /// This method **efficiently looks up a key** using a fast in-memory index,
-    /// and returns the latest corresponding value if found.
-    ///
-    /// # Parameters:
-    /// - `key`: The **binary key** whose latest value is to be retrieved.
-    ///
-    /// # Returns:
-    /// - `Some(EntryHandle)`: A handle to the entry containing the data and metadata.
-    /// - `None`: If the key does not exist or is deleted.
-    ///
-    /// # Notes:
-    /// - The returned `EntryHandle` provides zero-copy access to the stored data.
     fn read(&self, key: &[u8]) -> Option<EntryHandle> {
         let mmap_arc = self.get_mmap_arc();
         let key_indexer_guard = self.key_indexer.read().ok()?;
@@ -295,383 +123,130 @@ impl DataStoreReader for DataStore {
         Self::read_hashed_with_ctx(key_hash, &mmap_arc, &key_indexer_guard)
     }
 
-    /// Reads many keys in one shot.
-    ///
-    /// This is the **vectorized** counterpart to [`read`].  
-    /// It takes a slice of raw-byte keys and returns a `Vec` whose *i-th* element
-    /// is the result of looking up the *i-th* key.
-    ///
-    /// *   **Zero-copy** – each `Some(EntryHandle)` points directly into the
-    ///     shared `Arc<Mmap>`; no payload is copied.
-    /// *   **Constant-time per key** – the in-memory [`KeyIndexer`] map is used
-    ///     for each lookup, so the complexity is *O(n)* where *n* is
-    ///     `keys.len()`.
-    /// *   **Thread-safe** – a read lock on the index is taken once for the whole
-    ///     batch, so concurrent writers are still blocked only for the same short
-    ///     critical section that a single `read` would need.
-    ///
-    /// #### Error handling
-    /// *If* the index lock is poisoned the function falls back to “best-effort”
-    /// semantics and returns a vector of `None`s (one per requested key).  
-    /// This keeps the signature simple (`Vec<Option<…>>`) while still signalling
-    /// that the read failed.
     fn batch_read(&self, keys: &[&[u8]]) -> Result<Vec<Option<EntryHandle>>> {
-        use crate::storage_engine::digest::compute_hash_batch;
-
-        // 1. Grab the mmap once ----------------------------------------------------
         let mmap_arc = self.get_mmap_arc();
-
-        // 2. Read-lock the index.  On poisoning → bubble up an error.
         let key_indexer_guard = self.key_indexer.read().map_err(|_| {
             Error::new(
                 ErrorKind::Other,
                 "Key-index lock poisoned during batch_read",
             )
         })?;
-
-        // 3. Hash all keys outside the critical section ---------------------------
         let hashes = compute_hash_batch(keys);
-
-        // 4. Probe the index -------------------------------------------------------
         let results = hashes
             .into_iter()
             .map(|h| Self::read_hashed_with_ctx(h, &mmap_arc, &key_indexer_guard))
             .collect();
-
         Ok(results)
     }
 
-    /// Retrieves metadata for a given key.
-    ///
-    /// This method looks up a key in the storage and returns its associated metadata.
-    ///
-    /// # Parameters:
-    /// - `key`: The **binary key** whose metadata is to be retrieved.
-    ///
-    /// # Returns:
-    /// - `Some(&EntryMetadata)`: Metadata for the key if it exists.
-    /// - `None`: If the key does not exist in the storage.
     fn read_metadata(&self, key: &[u8]) -> Result<Option<EntryMetadata>> {
         Ok(self.read(key).map(|entry| entry.metadata().clone()))
     }
 
-    /// Counts the number of **active** entries in the storage.
-    ///
-    /// This method iterates through the storage file and counts **only the latest versions**
-    /// of keys, skipping deleted or outdated entries.
-    ///
-    /// # Returns:
-    /// - The **total count** of active key-value pairs in the database.
     fn count(&self) -> Result<usize> {
         Ok(self.iter_entries().count())
     }
 
-    /// Retrieves the **total size** of the storage file.
-    ///
-    /// This method queries the **current file size** of the storage file on disk.
-    ///
-    /// # Returns:
-    /// - `Ok(file_size_in_bytes)` if successful.
-    /// - `Err(std::io::Error)` if the file cannot be accessed.
     fn get_storage_size(&self) -> Result<u64> {
         std::fs::metadata(&self.path).map(|meta| meta.len())
     }
 }
 
 impl DataStore {
-    /// Opens an **existing** or **new** append-only storage file.
-    ///
-    /// This function:
-    /// 1. **Opens the file** in read/write mode (creating it if necessary).
-    /// 2. **Maps the file** into memory using `mmap` for fast access.
-    /// 3. **Recovers the valid chain**, ensuring **data integrity**.
-    /// 4. **Re-maps** the file after recovery to reflect the correct state.
-    /// 5. **Builds an in-memory index** for **fast key lookups**.
-    ///
-    /// # Parameters:
-    /// - `path`: The **file path** where the storage is located.
-    ///
-    /// # Returns:
-    /// - `Ok(DataStore)`: A **new storage instance**.
-    /// - `Err(std::io::Error)`: If any file operation fails.
     pub fn open(path: &Path) -> Result<Self> {
         let file = Self::open_file_in_append_mode(path)?;
         let file_len = file.get_ref().metadata()?.len();
 
-        // First mmap the file
         let mmap = Self::init_mmap(&file)?;
-
-        // Recover valid chain using mmap, not file
         let final_len = Self::recover_valid_chain(&mmap, file_len)?;
 
-        // TODO: Don't automatically do this; make it configurable with parameter
         if final_len < file_len {
-            // TODO: If open in read-only mode, reject the call
             warn!(
                 "Truncating corrupted data in {} from offset {} to {}.",
                 path.display(),
                 final_len,
                 file_len
             );
-
-            // Close the file before truncation
             drop(mmap);
             drop(file);
-
-            // Reopen the file in read-write mode and truncate it
             let file = OpenOptions::new().read(true).write(true).open(path)?;
             file.set_len(final_len)?;
-            file.sync_all()?; // Ensure OS writes take effect
-
-            // Now reopen everything fresh
+            file.sync_all()?;
             return Self::open(path);
         }
 
-        let key_indexer = KeyIndexer::build(&mmap, final_len);
+        let mmap_arc = Arc::new(mmap);
+        let mmap_for_indexer: &'static Mmap = unsafe { &*(Arc::as_ptr(&mmap_arc) as *const Mmap) };
+        let key_indexer = KeyIndexer::build(mmap_for_indexer, final_len);
 
         Ok(Self {
-            file: Arc::new(RwLock::new(file)), // Wrap in RwLock
-            mmap: Arc::new(Mutex::new(Arc::new(mmap))),
+            file: Arc::new(RwLock::new(file)),
+            mmap: Arc::new(Mutex::new(mmap_arc)),
             tail_offset: final_len.into(),
             key_indexer: Arc::new(RwLock::new(key_indexer)),
             path: path.to_path_buf(),
         })
     }
 
-    /// Opens an **existing** append-only storage file.
-    ///
-    /// This function verifies that the file exists before attempting to open it.
-    /// If the file does not exist or is not a valid file, an error is returned.
-    ///
-    /// # Parameters:
-    /// - `path`: The **file path** of the storage file.
-    ///
-    /// # Returns:
-    /// - `Ok(DataStore)`: A **new storage instance** if the file exists and can be opened.
-    /// - `Err(std::io::Error)`: If the file does not exist or is invalid.
-    ///
-    /// # Notes:
-    /// - Unlike `open()`, this function **does not create** a new storage file if the
-    ///   specified file does not exist.
-    /// - If the file is **missing** or is not a regular file, an error is returned.
-    /// - This is useful in scenarios where the caller needs to **ensure** that they are
-    ///   working with an already existing storage file.
     pub fn open_existing(path: &Path) -> Result<Self> {
-        // Errors if the file does not exist or is not a valid file
         verify_file_existence(&path)?;
-
         Self::open(path)
     }
 
-    /// Workaround for directly opening in **append mode** causing permissions issues on Windows
-    ///
-    /// The file is opened normally and the **cursor is moved to the end.
-    ///
-    /// Unix family unaffected by this issue, but this standardizes their handling.
-    ///
-    /// # Parameters:
-    /// - `path`: The **file path** of the storage file.
-    ///
-    /// # Returns:
-    /// - `Ok(BufWriter<File>)`: A buffered writer pointing to the file.
-    /// - `Err(std::io::Error)`: If the file could not be opened.
     fn open_file_in_append_mode(path: &Path) -> Result<BufWriter<File>> {
-        // Note: If using `append` here, Windows may throw an error with the message:
-        // "Failed to open storage". A workaround is to open the file normally, then
-        // move the cursor to the end of the file.
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .open(path)?;
-
-        file.seek(SeekFrom::End(0))?; // Move cursor to end to prevent overwriting
-
+        file.seek(SeekFrom::End(0))?;
         Ok(BufWriter::new(file))
     }
 
-    /// Initializes a memory-mapped file for fast access.
-    ///
-    /// This function creates a memory-mapped file (`mmap`) from a `BufWriter<File>`.
-    /// It provides a read-only view of the file, allowing efficient direct access to
-    /// stored data without unnecessary copies.
-    ///
-    /// # Parameters:
-    /// - `file`: A reference to a `BufWriter<File>`, which must be flushed before
-    ///   mapping to ensure all written data is visible.
-    ///
-    /// # Returns:
-    /// - `Ok(Mmap)`: A memory-mapped view of the file.
-    /// - `Err(std::io::Error)`: If the mapping fails.
-    ///
-    /// # Notes:
-    /// - The `BufWriter<File>` should be flushed before calling this function to
-    ///   ensure that all pending writes are persisted.
-    /// - The memory mapping remains valid as long as the underlying file is not truncated
-    ///   or modified in ways that invalidate the mapping.
-    ///
-    /// # Safety:
-    /// - This function uses an **unsafe** operation (`memmap2::MmapOptions::map`).
-    ///   The caller must ensure that the mapped file is not resized or closed while
-    ///   the mapping is in use, as this could lead to undefined behavior.
     fn init_mmap(file: &BufWriter<File>) -> Result<Mmap> {
         unsafe { memmap2::MmapOptions::new().map(file.get_ref()) }
     }
 
-    /// Returns a cloned `Arc<Mmap>`, providing a shared reference to the memory-mapped file.
-    ///
-    /// # How It Works:
-    /// - Acquires the `Mutex<Arc<Mmap>>` lock to access the current memory-mapped file.
-    /// - Clones the `Arc<Mmap>` to create another reference to the **same underlying memory**.
-    /// - Releases the lock immediately (`drop(guard)`) to allow other threads to proceed.
-    ///
-    /// # Important:
-    /// - **Cloning the `Arc<Mmap>` does not duplicate the memory-mapped file.**  
-    ///   Instead, it creates a new reference to the existing memory region,  
-    ///   ensuring efficient, zero-copy access.
-    /// - The returned `Arc<Mmap>` remains valid as long as at least one reference exists.
-    ///
-    /// # Returns:
-    /// - A **shared reference** (`Arc<Mmap>`) to the current memory-mapped file.
-    ///
-    /// # Safety:
-    /// - The returned `Arc<Mmap>` must not be used after a file truncation or remap.
-    ///   Ensure proper synchronization when modifying the underlying storage.
     #[inline]
     fn get_mmap_arc(&self) -> Arc<Mmap> {
-        // Briefly acquire the guard and release so that others can proceed
         let guard = self.mmap.lock().unwrap();
         let mmap_clone = guard.clone();
         drop(guard);
-
         mmap_clone
     }
 
-    /// Re-maps the storage file and updates the key index after a write operation.
-    ///
-    /// This function performs two key tasks:
-    /// 1. **Re-maps the file (`mmap`)**: Ensures that newly written data is visible
-    ///    to readers by creating a fresh memory-mapped view of the storage file.
-    /// 2. **Updates the key index**: Inserts new key hash-to-offset mappings into
-    ///    the in-memory key index, ensuring efficient key lookups for future reads.
-    ///
-    /// # Parameters:
-    /// - `write_guard`: A locked reference to the `BufWriter<File>`, ensuring that
-    ///   writes are completed before remapping and indexing.
-    /// - `key_hash_offsets`: A slice of `(key_hash, tail_offset)` tuples containing
-    ///   the latest key mappings to be added to the index.
-    /// - `tail_offset`: The **new absolute file offset** after the most recent write.
-    ///   This represents the byte position where the next write operation should begin.
-    ///   It is updated to reflect the latest valid data in the storage.
-    ///
-    /// # Returns:
-    /// - `Ok(())` if the reindexing process completes successfully.
-    /// - `Err(std::io::Error)` if file metadata retrieval, memory mapping, or
-    ///   key index updates fail.
-    ///
-    /// # Important:
-    /// - **The write operation must be flushed before calling `reindex`** to ensure
-    ///   all pending writes are persisted and visible in the new memory-mapped file.
-    ///   This prevents potential inconsistencies where written data is not reflected
-    ///   in the remapped view.
-    ///
-    /// # Safety:
-    /// - This function should be called **immediately after a write operation**
-    ///   to ensure the file is in a consistent state before remapping.
-    /// - The function acquires locks on both the `mmap` and `key_indexer`
-    ///   to prevent race conditions while updating shared structures.
-    ///
-    /// # Locks Acquired:
-    /// - `mmap` (`Mutex<Arc<Mmap>>`) is locked to update the memory-mapped file.
-    /// - `key_indexer` (`RwLock<HashMap<u64, u64>>`) is locked to modify key mappings.
     fn reindex(
         &self,
         write_guard: &std::sync::RwLockWriteGuard<'_, BufWriter<File>>,
         key_hash_offsets: &[(u64, u64)],
         tail_offset: u64,
     ) -> std::io::Result<()> {
-        // Create a new Mmap from the file
         let new_mmap = Self::init_mmap(write_guard)?;
-
-        // Obtain the lock guards
         let mut mmap_guard = self.mmap.lock().unwrap();
         let mut key_indexer_guard = self.key_indexer.write().map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::Other, "Failed to acquire index lock")
         })?;
 
-        // Update tail_offset (or any other fields)
-        let new_offset = write_guard.get_ref().metadata()?.len();
-        self.tail_offset
-            .store(new_offset, std::sync::atomic::Ordering::Release);
-
-        for (key_hash, tail_offset) in key_hash_offsets.iter() {
-            key_indexer_guard.insert(*key_hash, *tail_offset);
+        for (key_hash, offset) in key_hash_offsets.iter() {
+            key_indexer_guard.insert(*key_hash, *offset);
         }
 
-        // Overwrite the old Arc<Mmap> with the new one
         *mmap_guard = Arc::new(new_mmap);
-
         self.tail_offset.store(tail_offset, Ordering::Release);
-
-        // These are automatically dropped by Rust once leaving scope, but calling them for good measure
-        drop(mmap_guard);
-        drop(key_indexer_guard);
 
         Ok(())
     }
 
-    /// Returns the storage file path.
-    ///
-    /// # Returns:
-    /// - A `PathBuf` containing the path to the storage file.
     pub fn get_path(&self) -> PathBuf {
-        /*
-        This function **does not** clone or duplicate the actual storage file.
-        It only returns a clone of the in-memory `PathBuf` reference that
-        represents the file path.
-
-        `PathBuf::clone()` creates a shallow copy of the path, which is
-        inexpensive since it only duplicates the internal path buffer.
-
-        For more details, see:
-        https://doc.rust-lang.org/std/path/struct.PathBuf.html
-        */
         self.path.clone()
     }
 
-    /// Retrieves an iterator over all valid entries in the storage.
-    ///
-    /// This iterator allows scanning the storage file and retrieving **only the most recent**
-    /// versions of each key.
-    ///
-    /// # Returns:
-    /// - An `EntryIterator` instance for iterating over valid entries.
     pub fn iter_entries(&self) -> EntryIterator {
         let mmap_clone = self.get_mmap_arc();
-
         let tail_offset = self.tail_offset.load(Ordering::Acquire);
-
         EntryIterator::new(mmap_clone, tail_offset)
     }
 
-    /// Recovers the **latest valid chain** of entries from the storage file.
-    ///
-    /// This function **scans backward** through the file, verifying that each entry
-    /// correctly references the previous offset. It determines the **last valid
-    /// storage position** to ensure data integrity.
-    ///
-    /// # How It Works:
-    /// - Scans from the last written offset **backward**.
-    /// - Ensures each entry correctly points to its **previous offset**.
-    /// - Stops at the **deepest valid chain** that reaches offset `0`.
-    ///
-    /// # Parameters:
-    /// - `mmap`: A reference to the **memory-mapped file**.
-    /// - `file_len`: The **current size** of the file in bytes.
-    ///
-    /// # Returns:
-    /// - `Ok(final_valid_offset)`: The last **valid** byte offset.
-    /// - `Err(std::io::Error)`: If a file read or integrity check fails
     fn recover_valid_chain(mmap: &Mmap, file_len: u64) -> Result<u64> {
         if file_len < METADATA_SIZE as u64 {
             return Ok(0);
@@ -679,11 +254,8 @@ impl DataStore {
 
         let mut cursor = file_len;
         let mut best_valid_offset = None;
-
         while cursor >= METADATA_SIZE as u64 {
             let metadata_offset = cursor - METADATA_SIZE as u64;
-
-            // Read metadata directly from `mmap`
             let metadata_bytes =
                 &mmap[metadata_offset as usize..(metadata_offset as usize + METADATA_SIZE)];
             let metadata = EntryMetadata::deserialize(metadata_bytes);
@@ -695,11 +267,9 @@ impl DataStore {
                 continue;
             }
 
-            // Trace back the entire chain from this entry
             let mut chain_valid = true;
             let mut back_cursor = entry_start;
             let mut total_size = (metadata_offset - entry_start) + METADATA_SIZE as u64;
-            let mut temp_chain = vec![metadata_offset];
 
             while back_cursor != 0 {
                 if back_cursor < METADATA_SIZE as u64 {
@@ -708,55 +278,31 @@ impl DataStore {
                 }
 
                 let prev_metadata_offset = back_cursor - METADATA_SIZE as u64;
-
-                // Read previous entry metadata directly from `mmap`
                 let prev_metadata_bytes = &mmap[prev_metadata_offset as usize
                     ..(prev_metadata_offset as usize + METADATA_SIZE)];
                 let prev_metadata = EntryMetadata::deserialize(prev_metadata_bytes);
 
                 let entry_size = prev_metadata_offset.saturating_sub(prev_metadata.prev_offset);
                 total_size += entry_size + METADATA_SIZE as u64;
-
                 if prev_metadata.prev_offset >= prev_metadata_offset {
                     chain_valid = false;
                     break;
                 }
 
-                temp_chain.push(prev_metadata_offset);
                 back_cursor = prev_metadata.prev_offset;
             }
 
-            // Only accept the deepest valid chain that reaches `offset = 0`
             if chain_valid && back_cursor == 0 && total_size <= file_len {
-                debug!(
-                    "Found valid chain of {} entries. Ending at offset {}.",
-                    temp_chain.len(),
-                    metadata_offset + METADATA_SIZE as u64
-                );
                 best_valid_offset = Some(metadata_offset + METADATA_SIZE as u64);
-                break; // Stop checking further offsets since we found the best chain
+                break;
             }
 
             cursor -= 1;
         }
 
-        let final_len = best_valid_offset.unwrap_or(0);
-        Ok(final_len)
+        Ok(best_valid_offset.unwrap_or(0))
     }
 
-    /// Writes an entry using a **precomputed key hash** and a streaming `Read` source.
-    ///
-    /// This is a **low-level** method that operates like `write_stream`, but requires
-    /// the key to be hashed beforehand. It is primarily used internally to avoid
-    /// redundant hash computations when writing multiple entries.
-    ///
-    /// # Parameters:
-    /// - `key_hash`: The **precomputed hash** of the key.
-    /// - `reader`: A **streaming reader** (`Read` trait) supplying the entry's content.
-    ///
-    /// # Returns:
-    /// - `Ok(offset)`: The file offset where the entry was written.
-    /// - `Err(std::io::Error)`: If a write or I/O operation fails.
     pub fn write_stream_with_key_hash<R: Read>(
         &self,
         key_hash: u64,
@@ -765,35 +311,27 @@ impl DataStore {
         let mut file = self.file.write().map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::Other, "Failed to acquire file lock")
         })?;
-
         let prev_offset = self.tail_offset.load(Ordering::Acquire);
 
-        let mut buffer = vec![0; WRITE_STREAM_BUFFER_SIZE]; // 64KB buffer
-        let mut aligned_buffer = vec![0; WRITE_STREAM_BUFFER_SIZE]; // Aligned buffer for SIMD copy
+        let mut buffer = vec![0; WRITE_STREAM_BUFFER_SIZE];
         let mut total_written = 0;
         let mut checksum_state = crc32fast::Hasher::new();
-
-        let mut is_null_only = true; // Flag to track NULL-byte-only payload
+        let mut is_null_only = true;
 
         while let Ok(bytes_read) = reader.read(&mut buffer) {
             if bytes_read == 0 {
                 break;
             }
 
-            // Check if all bytes in buffer match NULL_BYTE
             if buffer[..bytes_read].iter().any(|&b| b != NULL_BYTE[0]) {
                 is_null_only = false;
             }
 
-            // Use SIMD to optimize memory copy
-            simd_copy(&mut aligned_buffer[..bytes_read], &buffer[..bytes_read]);
-
-            file.write_all(&aligned_buffer[..bytes_read])?;
-            checksum_state.update(&aligned_buffer[..bytes_read]); // Update checksum
+            file.write_all(&buffer[..bytes_read])?;
+            checksum_state.update(&buffer[..bytes_read]);
             total_written += bytes_read;
         }
 
-        // Reject if the entire stream was NULL bytes
         if total_written > 0 && is_null_only {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -801,78 +339,28 @@ impl DataStore {
             ));
         }
 
-        let checksum_u32 = checksum_state.finalize();
-        let checksum = checksum_u32.to_le_bytes();
-
+        let checksum = checksum_state.finalize().to_le_bytes();
         let metadata = EntryMetadata {
             key_hash,
             prev_offset,
             checksum,
         };
-
-        // Write metadata **after** payload
         file.write_all(&metadata.serialize())?;
-        file.flush()?; // Ensure data is written to disk
+        file.flush()?;
 
         let tail_offset = prev_offset + total_written as u64 + METADATA_SIZE as u64;
-
         self.reindex(
             &file,
-            &vec![(key_hash, tail_offset - METADATA_SIZE as u64)],
+            &[(key_hash, tail_offset - METADATA_SIZE as u64)],
             tail_offset,
         )?;
-
         Ok(tail_offset)
     }
 
-    /// Writes an entry using a **precomputed key hash** and a payload.
-    ///
-    /// This method is a **low-level** alternative to `write()`, allowing direct
-    /// specification of the key hash. It is mainly used for optimized workflows
-    /// where the key hash is already known, avoiding redundant computations.
-    ///
-    /// # Parameters:
-    /// - `key_hash`: The **precomputed hash** of the key.
-    /// - `payload`: The **data payload** to be stored.
-    ///
-    /// # Returns:
-    /// - `Ok(offset)`: The file offset where the entry was written.
-    /// - `Err(std::io::Error)`: If a write operation fails.
-    ///
-    /// # Notes:
-    /// - The caller is responsible for ensuring that `key_hash` is correctly computed.
-    /// - This method **locks the file for writing** to maintain consistency.
-    /// - If writing **multiple entries**, consider using `batch_write_hashed_payloads()`.
     pub fn write_with_key_hash(&self, key_hash: u64, payload: &[u8]) -> Result<u64> {
         self.batch_write_hashed_payloads(vec![(key_hash, payload)], false)
     }
 
-    /// Writes multiple key-value pairs as a **single transaction**, using precomputed key hashes.
-    ///
-    /// This method efficiently appends multiple entries in a **batch operation**,
-    /// reducing lock contention and improving performance for bulk writes.
-    ///
-    /// # Parameters:
-    /// - `hashed_payloads`: A **vector of precomputed key hashes and payloads**, where:
-    ///   - `key_hash`: The **precomputed hash** of the key.
-    ///   - `payload`: The **data payload** to be stored.
-    ///
-    /// # Returns:
-    /// - `Ok(final_offset)`: The file offset after all writes.
-    /// - `Err(std::io::Error)`: If a write operation fails.
-    ///
-    /// # Notes:
-    /// - **File locking is performed only once** for all writes, improving efficiency.
-    /// - If an entry's `payload` is empty, an error is returned.
-    /// - This method uses **SIMD-accelerated memory copy (`simd_copy`)** to optimize write
-    ///   performance.
-    /// - **Metadata (checksums, offsets) is written after payloads** to ensure data integrity.
-    /// - After writing, the memory-mapped file (`mmap`) is **remapped** to reflect updates.
-    ///
-    /// # Efficiency Considerations:
-    /// - **Faster than multiple `write()` calls**, since it reduces lock contention.
-    /// - Suitable for **bulk insertions** where key hashes are known beforehand.
-    /// - If keys are available but not hashed, use `batch_write()` instead.
     pub fn batch_write_hashed_payloads(
         &self,
         hashed_payloads: Vec<(u64, &[u8])>,
@@ -880,13 +368,12 @@ impl DataStore {
     ) -> Result<u64> {
         let mut file = self.file.write().map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::Other, "Failed to acquire file lock")
-        })?; // Lock only the file, not the whole struct
+        })?;
 
         let mut buffer = Vec::new();
         let mut tail_offset = self.tail_offset.load(Ordering::Acquire);
 
         let mut key_hash_offsets: Vec<(u64, u64)> = Vec::with_capacity(hashed_payloads.len());
-
         for (key_hash, payload) in hashed_payloads {
             if !allow_null_bytes && payload == NULL_BYTE {
                 return Err(std::io::Error::new(
@@ -904,56 +391,34 @@ impl DataStore {
 
             let prev_offset = tail_offset;
             let checksum = compute_checksum(payload);
-
             let metadata = EntryMetadata {
                 key_hash,
                 prev_offset,
                 checksum,
             };
-
             let payload_len = payload.len();
 
             let mut entry: Vec<u8> = vec![0u8; payload_len + METADATA_SIZE];
-
-            // Use SIMD to copy payload into buffer
             simd_copy(&mut entry[..payload.len()], payload);
-
-            // Copy metadata normally (small size, not worth SIMD)
             entry[payload.len()..].copy_from_slice(&metadata.serialize());
-
             buffer.extend_from_slice(&entry);
 
             tail_offset += entry.len() as u64;
-
             key_hash_offsets.push((key_hash, tail_offset - METADATA_SIZE as u64));
         }
 
         file.write_all(&buffer)?;
         file.flush()?;
 
-        self.reindex(&file, &key_hash_offsets, tail_offset)?; // Ensure mmap updates
+        self.reindex(&file, &key_hash_offsets, tail_offset)?;
 
         Ok(self.tail_offset.load(Ordering::Acquire))
     }
 
-    /// Reads the last entry stored in the database.
-    ///
-    /// This method retrieves the **most recently appended** entry in the storage.
-    /// It does not check for key uniqueness; it simply returns the last-written
-    /// data segment from the memory-mapped file.
-    ///
-    /// # Returns:
-    /// - `Some(EntryHandle)`: A handle to the last entry containing the data and metadata.
-    /// - `None`: If the storage is empty or corrupted.
-    ///
-    /// # Notes:
-    /// - The returned `EntryHandle` allows zero-copy access to the entry data.
+    // METHOD ADDED BACK
     pub fn read_last_entry(&self) -> Option<EntryHandle> {
         let mmap_arc = self.get_mmap_arc();
-
-        // 4) Use `mmap_arc` to find the last entry boundaries
         let tail_offset = self.tail_offset.load(std::sync::atomic::Ordering::Acquire);
-
         if tail_offset < METADATA_SIZE as u64 || mmap_arc.len() == 0 {
             return None;
         }
@@ -963,7 +428,6 @@ impl DataStore {
             return None;
         }
 
-        // Read the last entry's metadata
         let metadata_bytes = &mmap_arc[metadata_offset..metadata_offset + METADATA_SIZE];
         let metadata = EntryMetadata::deserialize(metadata_bytes);
 
@@ -973,7 +437,6 @@ impl DataStore {
             return None;
         }
 
-        // 5) Create a handle that "owns" the Arc and the byte range
         Some(EntryHandle {
             mmap_arc,
             range: entry_start..entry_end,
@@ -981,35 +444,14 @@ impl DataStore {
         })
     }
 
-    /// Internal helper that does the real work for `read`/`batch_read`.
-    ///
-    /// *   `key` – raw-byte key we are searching for.  
-    /// *   `mmap_arc` – the current shared memory-map.  
-    /// *   `key_indexer` – **already locked** read-only view of the index.  
-    ///
-    /// The function:
-    /// 1.  Hashes `key` with XXH3 (same as writers do).
-    /// 2.  Looks the hash up in the index; bails out early if absent.
-    /// 3.  Validates that the stored offset and metadata still fit inside the
-    ///     current `mmap` (guards against truncated / corrupted files).
-    /// 4.  Creates and returns an `EntryHandle` that spans the payload slice in
-    ///     the `mmap`.
-    ///
-    /// It deliberately **does not** take any locks itself – that must be done by
-    /// the caller so that `batch_read` can reuse the same lock for many lookups.
-    ///
-    /// `None` is returned when:
-    /// * the key is unknown,
-    /// * the mapped file looks inconsistent (bounds checks fail), or
-    /// * the latest record for the key is a tomb-stone (one-byte NULL payload).
+    // METHOD ADDED BACK
     #[inline]
     pub fn read_hashed_with_ctx(
         key_hash: u64,
         mmap_arc: &Arc<Mmap>,
-        key_indexer: &KeyIndexer, // already locked
+        key_indexer: &KeyIndexer,
     ) -> Option<EntryHandle> {
-        let offset = *key_indexer.get(&key_hash)?;
-
+        let offset = key_indexer.get(&key_hash)?;
         if offset as usize + METADATA_SIZE > mmap_arc.len() {
             return None;
         }
@@ -1019,12 +461,10 @@ impl DataStore {
 
         let entry_start = metadata.prev_offset as usize;
         let entry_end = offset as usize;
-
         if entry_start >= entry_end || entry_end > mmap_arc.len() {
             return None;
         }
 
-        // Tomb-stone?  → treat as deleted.
         if entry_end - entry_start == 1 && &mmap_arc[entry_start..entry_end] == NULL_BYTE {
             return None;
         }
@@ -1036,154 +476,63 @@ impl DataStore {
         })
     }
 
-    /// Copies an entry handle to a **different storage container**.
-    ///
-    /// This function:
-    /// - Extracts metadata and content from the given `EntryHandle`.
-    /// - Writes the entry into the `target` storage.
-    ///
-    /// # Parameters:
-    /// - `entry`: The **entry handle** to be copied.
-    /// - `target`: The **destination storage** where the entry should be copied.
-    ///
-    /// # Returns:
-    /// - `Ok(target_offset)`: The file offset where the copied entry was written.
-    /// - `Err(std::io::Error)`: If a write operation fails.
-    ///
-    /// # Notes:
-    /// - This is a **low-level function** used by `copy_entry` and related operations.
-    /// - The `entry` remains **unchanged** in the original storage.
     fn copy_entry_handle(&self, entry: &EntryHandle, target: &DataStore) -> Result<u64> {
-        let metadata = entry.metadata();
-
-        let mut entry_stream = EntryStream::from(entry.clone_arc()); // Convert to Arc to keep ownership
-
-        let target_offset =
-            target.write_stream_with_key_hash(metadata.key_hash, &mut entry_stream)?;
-
-        Ok(target_offset)
+        let mut entry_stream = EntryStream::from(entry.clone_arc());
+        target.write_stream_with_key_hash(entry.key_hash(), &mut entry_stream)
     }
 
-    /// Compacts the storage by keeping only the latest version of each key.
-    ///
-    /// # ⚠️ WARNING:
-    /// - **This function should only be used when a single thread is accessing the storage.**
-    /// - While `&mut self` prevents concurrent **mutations**, it **does not** prevent
-    ///   other threads from holding shared references (`&DataStore`) and performing reads.
-    /// - If the `DataStore` instance is wrapped in `Arc<DataStore>`, multiple threads
-    ///   may still hold **read** references while compaction is running, potentially
-    ///   leading to inconsistent reads.
-    /// - If stricter concurrency control is required, **manual synchronization should
-    ///   be enforced externally.**
-    ///
-    /// # Behavior:
-    /// - Creates a **temporary compacted file** containing only the latest versions
-    ///   of stored keys.
-    /// - Swaps the original file with the compacted version upon success.
-    /// - Does **not** remove tombstone (deleted) entries due to the append-only model.
-    ///
-    /// # Returns:
-    /// - `Ok(())` if compaction completes successfully.
-    /// - `Err(std::io::Error)` if an I/O operation fails.
     pub fn compact(&mut self) -> std::io::Result<()> {
         let compacted_path = crate::utils::append_extension(&self.path, "bk");
+        info!("Starting compaction. Writing to: {:?}", compacted_path);
 
-        debug!("Starting compaction. Writing to: {:?}", compacted_path);
-
-        // Create a new DataStore instance for the compacted file
         let mut compacted_storage = DataStore::open(&compacted_path)?;
+        let mut index_pairs: Vec<(u64, u64)> = Vec::new();
 
-        // Iterate over all valid entries using your iterator
         for entry in self.iter_entries() {
-            self.copy_entry_handle(&entry, &mut compacted_storage)?;
+            let new_tail_offset = self.copy_entry_handle(&entry, &mut compacted_storage)?;
+            let stored_metadata_offset = new_tail_offset - METADATA_SIZE as u64;
+            index_pairs.push((entry.key_hash(), stored_metadata_offset));
         }
 
-        // Flush the compacted file
+        let indexed_up_to = compacted_storage.tail_offset.load(Ordering::Acquire);
+
         {
             let mut file_guard = compacted_storage.file.write().map_err(|e| {
                 std::io::Error::new(std::io::ErrorKind::Other, format!("Lock poisoned: {}", e))
             })?;
             file_guard.flush()?;
+            let underlying_file = file_guard.get_mut();
+            flush_static_index(underlying_file, &index_pairs, indexed_up_to)?;
         }
 
-        drop(compacted_storage); // ensure all writes are flushed before swapping
+        drop(compacted_storage);
 
-        debug!("Reduced backup completed. Swapping files...");
+        debug!("Compaction successful. Swapping files...");
         std::fs::rename(&compacted_path, &self.path)?;
-        info!("Compaction successful.");
+        info!("Compaction file swap complete.");
         Ok(())
     }
 
-    /// Estimates the potential space savings from compaction.
-    ///
-    /// This method scans the storage file and calculates the difference
-    /// between the total file size and the size required to keep only
-    /// the latest versions of all keys.
-    ///
-    /// # How It Works:
-    /// - Iterates through the entries, tracking the **latest version** of each key.
-    /// - Ignores older versions of keys to estimate the **optimized** storage footprint.
-    /// - Returns the **difference** between the total file size and the estimated compacted size.
     pub fn estimate_compaction_savings(&self) -> u64 {
         let total_size = self.get_storage_size().unwrap_or(0);
         let mut unique_entry_size: u64 = 0;
         let mut seen_keys = HashSet::with_hasher(Xxh3BuildHasher);
 
-        let mmap_arc = self.get_mmap_arc();
-
-        // Now we can safely iterate zero-copy
         for entry in self.iter_entries() {
-            // Convert pointer offsets relative to `mmap_arc`
-            let entry_start_offset = entry.as_ptr() as usize - mmap_arc.as_ptr() as usize;
-            let metadata_offset = entry_start_offset + entry.len();
-
-            if metadata_offset + METADATA_SIZE > mmap_arc.len() {
-                warn!("Skipping corrupted entry at offset {}", entry_start_offset);
-                continue;
-            }
-
-            let metadata_bytes = &mmap_arc[metadata_offset..metadata_offset + METADATA_SIZE];
-            let metadata = EntryMetadata::deserialize(metadata_bytes);
-
-            // Only count the latest version of each key
-            if seen_keys.insert(metadata.key_hash) {
-                unique_entry_size += entry.len() as u64 + METADATA_SIZE as u64;
+            if seen_keys.insert(entry.key_hash()) {
+                unique_entry_size += entry.size_with_metadata() as u64;
             }
         }
-
-        //  Return the difference between total size and the unique size
         total_size.saturating_sub(unique_entry_size)
     }
 
-    /// Provides access to the shared memory-mapped file (`Arc<Mmap>`) for testing.
-    ///
-    /// This method returns a cloned `Arc<Mmap>`, allowing test cases to inspect
-    /// the memory-mapped region while ensuring reference counting remains intact.
-    ///
-    /// # Notes:
-    /// - The returned `Arc<Mmap>` ensures safe access without invalidating the mmap.
-    /// - This function is only available in **test** and **debug** builds.
     #[cfg(any(test, debug_assertions))]
     pub fn get_mmap_arc_for_testing(&self) -> Arc<Mmap> {
         self.get_mmap_arc()
     }
 
-    /// Provides direct access to the raw pointer of the underlying memory map for testing.
-    ///
-    /// This method retrieves a raw pointer (`*const u8`) to the start of the memory-mapped file.
-    /// It is useful for validating zero-copy behavior and memory alignment in test cases.
-    ///
-    /// # Safety Considerations:
-    /// - The pointer remains valid **as long as** the mmap is not remapped or dropped.
-    /// - Dereferencing this pointer outside of controlled test environments **is unsafe**
-    ///   and may result in undefined behavior.
-    ///
-    /// # Notes:
-    /// - This function is only available in **test** and **debug** builds.
     #[cfg(any(test, debug_assertions))]
     pub fn arc_ptr(&self) -> *const u8 {
-        let mmap_arc = self.get_mmap_arc();
-
-        mmap_arc.as_ptr()
+        self.get_mmap_arc().as_ptr()
     }
 }

--- a/src/storage_engine/entry_stream.rs
+++ b/src/storage_engine/entry_stream.rs
@@ -27,7 +27,7 @@ use std::io::{self, Read};
 ///
 /// // Write some test data
 /// data_store.write(b"test_key", b"test_data");
-/// let entry_handle = data_store.read(b"test_key").unwrap();
+/// let entry_handle = data_store.read(b"test_key").unwrap().unwrap();
 ///
 /// // Assume `entry_handle` is obtained from storage
 /// let mut stream = EntryStream::from(entry_handle);

--- a/src/storage_engine/index_layer.rs
+++ b/src/storage_engine/index_layer.rs
@@ -1,0 +1,52 @@
+//! Thin wrapper: Static index + in-memory delta for recent writes.
+
+use super::static_hash_index::StaticHashIndex;
+use crate::storage_engine::digest::Xxh3BuildHasher;
+use std::{collections::HashMap, sync::RwLock};
+
+#[derive(Debug)]
+pub enum IndexLayer<'a> {
+    Static {
+        table: StaticHashIndex<'a>,
+        delta: RwLock<HashMap<u64, u64, Xxh3BuildHasher>>,
+    },
+    Legacy(RwLock<HashMap<u64, u64, Xxh3BuildHasher>>),
+}
+
+impl<'a> IndexLayer<'a> {
+    /// Creates a new IndexLayer with a static table and an empty delta map for new writes.
+    pub fn new_static(table: StaticHashIndex<'a>) -> Self {
+        Self::Static {
+            table,
+            delta: RwLock::new(HashMap::with_hasher(Xxh3BuildHasher)),
+        }
+    }
+
+    /// Creates a new IndexLayer that wraps a legacy HashMap.
+    pub fn new_legacy(map: HashMap<u64, u64, Xxh3BuildHasher>) -> Self {
+        Self::Legacy(RwLock::new(map))
+    }
+
+    #[inline]
+    pub fn get(&self, h: &u64) -> Option<u64> {
+        match self {
+            Self::Static { table, delta } => {
+                // Check the delta (recent writes) first. If not found, check the static table.
+                delta
+                    .read()
+                    .ok()
+                    .and_then(|d| d.get(h).copied())
+                    .or_else(|| table.get(*h))
+            }
+            Self::Legacy(map) => map.read().ok().and_then(|d| d.get(h).copied()),
+        }
+    }
+
+    #[inline]
+    pub fn insert(&self, h: u64, off: u64) -> Option<u64> {
+        match self {
+            Self::Static { delta, .. } => delta.write().ok().and_then(|mut d| d.insert(h, off)),
+            Self::Legacy(map) => map.write().ok().and_then(|mut d| d.insert(h, off)),
+        }
+    }
+}

--- a/src/storage_engine/key_indexer.rs
+++ b/src/storage_engine/key_indexer.rs
@@ -1,32 +1,46 @@
+use crate::storage_engine::IndexLayer;
 use crate::storage_engine::constants::*;
 use crate::storage_engine::digest::Xxh3BuildHasher;
-use crate::storage_engine::EntryMetadata;
+use crate::storage_engine::entry_metadata::EntryMetadata;
+use crate::storage_engine::{IndexFooter, StaticHashIndex};
+use log::info;
 use memmap2::Mmap;
 use std::collections::{HashMap, HashSet};
 
-pub struct KeyIndexer {
-    index: HashMap<u64, u64, Xxh3BuildHasher>,
+#[derive(Debug)]
+pub struct KeyIndexer<'a> {
+    index: IndexLayer<'a>,
 }
 
-impl KeyIndexer {
-    /// Builds an in-memory index for **fast key lookups**.
+impl<'a> KeyIndexer<'a> {
+    /// Builds an in-memory index for fast key lookups.
     ///
-    /// This function **scans the storage file** and constructs a **hashmap**
-    /// mapping each key's hash to its **latest** entry's file offset.
-    ///
-    /// # How It Works:
-    /// - Iterates **backward** from the latest offset to find the most recent version of each key.
-    /// - Skips duplicate keys to keep only the **most recent** entry.
-    /// - Stores the **latest offset** of each unique key in the index.
-    ///
-    /// # Parameters:
-    /// - `mmap`: A reference to the **memory-mapped file**.
-    /// - `tail_offset`: The **final byte offset** in the file (starting point for scanning).
-    ///
-    /// # Returns:
-    /// - A `HashMap<u64, u64>` mapping `key_hash` → `latest offset`.
-    pub fn build(mmap: &Mmap, tail_offset: u64) -> Self {
-        let mut index = HashMap::with_hasher(Xxh3BuildHasher);
+    /// This function first attempts to load a persistent, memory-mapped static index.
+    /// If a valid static index is not found at the end of the file, it falls back
+    /// to the legacy method of scanning the file to build a HashMap in memory.
+    pub fn build(mmap: &'a Mmap, tail_offset: u64) -> Self {
+        // Attempt to read the static index footer from the end of the mmap'd file.
+        if let Some(footer) = IndexFooter::read_from(mmap) {
+            // A static index exists. Check if it's up-to-date with the data segment.
+            if footer.indexed_up_to == tail_offset {
+                info!("Loaded persistent static index from file. Startup will be fast.");
+                let static_index = StaticHashIndex::new(mmap, footer);
+                return Self {
+                    index: IndexLayer::new_static(static_index),
+                };
+            } else {
+                info!(
+                    "Static index is outdated (data has been added since last compaction). Falling back to legacy index build."
+                );
+            }
+        } else {
+            info!(
+                "No static index found. Building index from scratch (this may be slow for large files)."
+            );
+        }
+
+        // --- Fallback: Build the index using the legacy scan method ---
+        let mut index_map = HashMap::with_hasher(Xxh3BuildHasher);
         let mut seen_keys = HashSet::with_hasher(Xxh3BuildHasher);
         let mut cursor = tail_offset;
 
@@ -35,25 +49,25 @@ impl KeyIndexer {
             let metadata_bytes = &mmap[metadata_offset..metadata_offset + METADATA_SIZE];
             let metadata = EntryMetadata::deserialize(metadata_bytes);
 
-            // If this key is already seen, skip it (to keep the latest entry only)
+            // If this key has already been seen, skip it to keep only the latest entry
             if seen_keys.contains(&metadata.key_hash) {
                 cursor = metadata.prev_offset;
                 continue;
             }
 
-            // Mark key as seen and store its latest offset
             seen_keys.insert(metadata.key_hash);
-            index.insert(metadata.key_hash, metadata_offset as u64);
+            // The value is the offset of the *metadata*, not the payload.
+            index_map.insert(metadata.key_hash, metadata_offset as u64);
 
-            // Stop when reaching the first valid entry
             if metadata.prev_offset == 0 {
                 break;
             }
-
             cursor = metadata.prev_offset;
         }
 
-        Self { index }
+        Self {
+            index: IndexLayer::new_legacy(index_map),
+        }
     }
 
     #[inline]
@@ -62,7 +76,7 @@ impl KeyIndexer {
     }
 
     #[inline]
-    pub fn get(&self, key_hash: &u64) -> Option<&u64> {
+    pub fn get(&self, key_hash: &u64) -> Option<u64> {
         self.index.get(key_hash)
     }
 }

--- a/src/storage_engine/static_hash_index.rs
+++ b/src/storage_engine/static_hash_index.rs
@@ -1,0 +1,140 @@
+//! mmap-resident static hash table (key_hash → offset)
+//! – 16 B per slot  (u64 key, u64 offset)
+//! – open addressing, linear probe
+//! – no allocations, thread-safe read-only
+
+use memmap2::Mmap;
+use std::{
+    fs::File,
+    io::{Seek, SeekFrom, Write},
+};
+
+const FOOTER_MAGIC: u32 = 0x5348_5244; // "SHRD"
+const FOOTER_SIZE: usize = 32;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct IndexFooter {
+    pub index_offset: u64,
+    pub table_bytes: u64,
+    pub indexed_up_to: u64,
+    pub table_pow2: u32,
+    pub magic: u32,
+}
+
+impl IndexFooter {
+    pub fn read_from(mmap: &Mmap) -> Option<Self> {
+        if mmap.len() < FOOTER_SIZE {
+            return None;
+        }
+        let base = mmap.len() - FOOTER_SIZE;
+        let mut buf = [0u8; FOOTER_SIZE];
+        buf.copy_from_slice(&mmap[base..]);
+        let magic = u32::from_le_bytes(buf[28..32].try_into().unwrap());
+        if magic != FOOTER_MAGIC {
+            return None;
+        }
+        Some(Self {
+            index_offset: u64::from_le_bytes(buf[0..8].try_into().unwrap()),
+            table_bytes: u64::from_le_bytes(buf[8..16].try_into().unwrap()),
+            indexed_up_to: u64::from_le_bytes(buf[16..24].try_into().unwrap()),
+            table_pow2: u32::from_le_bytes(buf[24..28].try_into().unwrap()),
+            magic,
+        })
+    }
+
+    // This function signature is changed to take a mutable reference to the writer.
+    pub fn write<W: Write>(
+        w: &mut W,
+        off: u64,
+        bytes: u64,
+        upto: u64,
+        pow2: u32,
+    ) -> std::io::Result<()> {
+        w.write_all(&off.to_le_bytes())?;
+        w.write_all(&bytes.to_le_bytes())?;
+        w.write_all(&upto.to_le_bytes())?;
+        w.write_all(&pow2.to_le_bytes())?;
+        w.write_all(&FOOTER_MAGIC.to_le_bytes())?;
+        Ok(())
+    }
+}
+
+/// read-only view over an mmap’d static table
+#[derive(Debug)]
+pub struct StaticHashIndex<'a> {
+    mmap: &'a Mmap,
+    footer: IndexFooter,
+    slot_mask: u64,
+}
+
+impl<'a> StaticHashIndex<'a> {
+    pub fn new(mmap: &'a Mmap, footer: IndexFooter) -> Self {
+        let slot_cnt = footer.table_bytes / 16;
+        Self {
+            mmap,
+            footer,
+            slot_mask: slot_cnt as u64 - 1,
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, key_hash: u64) -> Option<u64> {
+        let mut idx = key_hash & self.slot_mask;
+        loop {
+            let base = (self.footer.index_offset + idx * 16) as usize;
+            if base + 16 > self.mmap.len() {
+                return None;
+            } // Bounds check
+            let stored = u64::from_le_bytes(self.mmap[base..base + 8].try_into().unwrap());
+            if stored == 0 {
+                return None;
+            }
+            if stored == key_hash {
+                return Some(u64::from_le_bytes(
+                    self.mmap[base + 8..base + 16].try_into().unwrap(),
+                ));
+            }
+            idx = (idx + 1) & self.slot_mask;
+        }
+    }
+}
+
+/// build a packed table in RAM and append it (+footer) to `file`
+pub fn flush_static_index(
+    file: &mut File,
+    pairs: &[(u64, u64)], // (key_hash, offset)
+    indexed_up_to: u64,
+) -> std::io::Result<()> {
+    let need_slots = (pairs.len() as f64 / 0.7).ceil() as u64; // Target 70% load factor
+    let pow2 = 64 - need_slots.leading_zeros();
+    let slots = 1u64 << pow2;
+    let mut table = vec![0u8; (slots * 16) as usize];
+
+    for &(k, off) in pairs {
+        let mut idx = xxhash_rust::xxh3::xxh3_64(&k.to_le_bytes()) & (slots - 1);
+        loop {
+            let base = (idx * 16) as usize;
+            let stored = u64::from_le_bytes(table[base..base + 8].try_into().unwrap());
+            if stored == 0 {
+                table[base..base + 8].copy_from_slice(&k.to_le_bytes());
+                table[base + 8..base + 16].copy_from_slice(&off.to_le_bytes());
+                break;
+            }
+            idx = (idx + 1) & (slots - 1);
+        }
+    }
+
+    let index_offset = file.seek(SeekFrom::End(0))?;
+    file.write_all(&table)?;
+    // The call to `IndexFooter::write` now passes `file` which is `&mut File`, matching the new signature.
+    IndexFooter::write(
+        file,
+        index_offset,
+        table.len() as u64,
+        indexed_up_to,
+        pow2 as u32,
+    )?;
+    file.flush()?;
+    Ok(())
+}

--- a/src/storage_engine/traits/reader.rs
+++ b/src/storage_engine/traits/reader.rs
@@ -1,6 +1,8 @@
 use crate::storage_engine::EntryMetadata;
 use std::io::Result;
 
+// TODO: Add `read_last_entry` here
+
 pub trait DataStoreReader {
     type EntryHandleType;
 

--- a/src/storage_engine/traits/reader.rs
+++ b/src/storage_engine/traits/reader.rs
@@ -6,7 +6,7 @@ use std::io::Result;
 pub trait DataStoreReader {
     type EntryHandleType;
 
-    fn read(&self, key: &[u8]) -> Option<Self::EntryHandleType>;
+    fn read(&self, key: &[u8]) -> Result<Option<Self::EntryHandleType>>;
 
     fn batch_read(&self, keys: &[&[u8]]) -> Result<Vec<Option<Self::EntryHandleType>>>;
 

--- a/src/storage_engine/traits/reader.rs
+++ b/src/storage_engine/traits/reader.rs
@@ -8,6 +8,8 @@ pub trait DataStoreReader {
 
     fn read(&self, key: &[u8]) -> Result<Option<Self::EntryHandleType>>;
 
+    fn read_last_entry(&self) -> Result<Option<Self::EntryHandleType>>;
+
     fn batch_read(&self, keys: &[&[u8]]) -> Result<Vec<Option<Self::EntryHandleType>>>;
 
     fn read_metadata(&self, key: &[u8]) -> Result<Option<EntryMetadata>>;
@@ -22,6 +24,8 @@ pub trait AsyncDataStoreReader {
     type EntryHandleType;
 
     async fn read(&self, key: &[u8]) -> Result<Option<Self::EntryHandleType>>;
+
+    async fn read_last_entry(&self) -> Result<Option<Self::EntryHandleType>>;
 
     async fn batch_read(&self, keys: &[&[u8]]) -> Result<Vec<Option<Self::EntryHandleType>>>;
 

--- a/tests/basic_operations_tests.rs
+++ b/tests/basic_operations_tests.rs
@@ -24,7 +24,7 @@ mod tests {
         let payload = b"Hello, world!".as_slice();
         storage.write(key, payload).expect("Failed to append entry");
 
-        let last_entry = storage.read_last_entry().expect("No entry found");
+        let last_entry = storage.read_last_entry().unwrap().expect("No entry found");
         assert_eq!(
             last_entry.as_slice(),
             payload,
@@ -46,7 +46,10 @@ mod tests {
             storage.write(key, payload).expect("Failed to append entry");
         }
 
-        let last_entry = storage.read_last_entry().expect("No last entry found");
+        let last_entry = storage
+            .read_last_entry()
+            .unwrap()
+            .expect("No last entry found");
         assert_eq!(
             last_entry.as_slice(),
             entries.last().unwrap().1,
@@ -70,7 +73,10 @@ mod tests {
                 .expect("Failed to append entry");
         }
 
-        let last_entry = storage.read_last_entry().expect("No last entry found");
+        let last_entry = storage
+            .read_last_entry()
+            .unwrap()
+            .expect("No last entry found");
         assert_eq!(
             last_entry.as_slice(),
             payloads.last().unwrap().as_slice(),
@@ -86,7 +92,7 @@ mod tests {
         let payload = b"Hello, world!".as_slice();
         storage.write(key, payload).expect("Failed to append entry");
 
-        let retrieved = storage.read(key);
+        let retrieved = storage.read(key).unwrap();
 
         assert!(
             retrieved.is_some(),
@@ -132,21 +138,30 @@ mod tests {
             .write(key2, updated_payload2)
             .expect("Failed to update entry");
 
-        let retrieved1 = storage.read(key1).expect("Entry for key1 should be found");
+        let retrieved1 = storage
+            .read(key1)
+            .unwrap()
+            .expect("Entry for key1 should be found");
         assert_eq!(
             retrieved1.as_slice(),
             updated_payload1,
             "Latest version of key1 was not retrieved"
         );
 
-        let retrieved2 = storage.read(key2).expect("Entry for key2 should be found");
+        let retrieved2 = storage
+            .read(key2)
+            .unwrap()
+            .expect("Entry for key2 should be found");
         assert_eq!(
             retrieved2.as_slice(),
             updated_payload2,
             "Latest version of key2 was not retrieved"
         );
 
-        let retrieved3 = storage.read(key3).expect("Entry for key3 should be found");
+        let retrieved3 = storage
+            .read(key3)
+            .unwrap()
+            .expect("Entry for key3 should be found");
         assert_eq!(
             retrieved3.as_slice(),
             initial_payload3,
@@ -173,7 +188,10 @@ mod tests {
         let payload = b"Existing file test".as_slice();
         storage.write(key, payload).expect("Failed to write entry");
 
-        let retrieved = storage.read(key).expect("Entry should exist in storage");
+        let retrieved = storage
+            .read(key)
+            .unwrap()
+            .expect("Entry should exist in storage");
         assert_eq!(
             retrieved.as_slice(),
             payload,

--- a/tests/batch_ops_tests.rs
+++ b/tests/batch_ops_tests.rs
@@ -30,7 +30,10 @@ fn test_batch_write_and_individual_reads() {
     storage.batch_write(&entries).expect("batch_write failed");
 
     for (k, v) in &entries {
-        let got = storage.read(k).expect("missing key written via batch");
+        let got = storage
+            .read(k)
+            .unwrap()
+            .expect("missing key written via batch");
         assert_eq!(got.as_slice(), *v);
     }
 }
@@ -115,8 +118,8 @@ fn test_batch_write_rejects_empty_payload_among_many() {
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 
     // Ensure *nothing* was persisted
-    assert!(storage.read(b"k1").is_none());
-    assert!(storage.read(b"k2").is_none());
+    assert!(storage.read(b"k1").unwrap().is_none());
+    assert!(storage.read(b"k2").unwrap().is_none());
     assert_eq!(
         storage.count().unwrap(),
         0,

--- a/tests/compaction_tests.rs
+++ b/tests/compaction_tests.rs
@@ -90,18 +90,33 @@ mod tests {
         storage.write(key7, &temp_payload2).expect("Append failed");
 
         // Ensure Data is Stored Correctly Before Compaction
-        assert_eq!(storage.read(key1).as_deref(), Some(text_payload2));
-        assert_eq!(storage.read(key2).as_deref(), Some(&binary_payload2[..]));
-        assert_eq!(storage.read(key4).as_deref(), Some(&integer_payload2[..]));
-        assert_eq!(storage.read(key5).as_deref(), Some(&float_payload2[..]));
-        assert_eq!(storage.read(key6).as_deref(), Some(mixed_payload2));
-        assert_eq!(storage.read(key7).as_deref(), Some(&temp_payload2[..]));
+        assert_eq!(storage.read(key1).unwrap().as_deref(), Some(text_payload2));
+        assert_eq!(
+            storage.read(key2).unwrap().as_deref(),
+            Some(&binary_payload2[..])
+        );
+        assert_eq!(
+            storage.read(key4).unwrap().as_deref(),
+            Some(&integer_payload2[..])
+        );
+        assert_eq!(
+            storage.read(key5).unwrap().as_deref(),
+            Some(&float_payload2[..])
+        );
+        assert_eq!(storage.read(key6).unwrap().as_deref(), Some(mixed_payload2));
+        assert_eq!(
+            storage.read(key7).unwrap().as_deref(),
+            Some(&temp_payload2[..])
+        );
 
         storage.delete_entry(key7).unwrap();
 
-        assert_eq!(storage.read(key7).as_deref(), None);
+        assert_eq!(storage.read(key7).unwrap().as_deref(), None);
 
-        let retrieved_struct = storage.read(key3).expect("Failed to retrieve struct");
+        let retrieved_struct = storage
+            .read(key3)
+            .unwrap()
+            .expect("Failed to retrieve struct");
         let deserialized_struct: CustomStruct = bincode::deserialize(retrieved_struct.as_slice())
             .expect("Failed to deserialize struct");
         assert_eq!(deserialized_struct, struct_payload2);
@@ -131,14 +146,26 @@ mod tests {
         let storage = DataStore::open(&path).expect("Failed to reopen storage after compaction");
 
         // Verify that only the latest versions remain
-        assert_eq!(storage.read(key1).as_deref(), Some(text_payload2));
-        assert_eq!(storage.read(key2).as_deref(), Some(&binary_payload2[..]));
-        assert_eq!(storage.read(key4).as_deref(), Some(&integer_payload2[..]));
-        assert_eq!(storage.read(key5).as_deref(), Some(&float_payload2[..]));
-        assert_eq!(storage.read(key6).as_deref(), Some(mixed_payload2));
-        assert_eq!(storage.read(key7).as_deref(), None);
+        assert_eq!(storage.read(key1).unwrap().as_deref(), Some(text_payload2));
+        assert_eq!(
+            storage.read(key2).unwrap().as_deref(),
+            Some(&binary_payload2[..])
+        );
+        assert_eq!(
+            storage.read(key4).unwrap().as_deref(),
+            Some(&integer_payload2[..])
+        );
+        assert_eq!(
+            storage.read(key5).unwrap().as_deref(),
+            Some(&float_payload2[..])
+        );
+        assert_eq!(storage.read(key6).unwrap().as_deref(), Some(mixed_payload2));
+        assert_eq!(storage.read(key7).unwrap().as_deref(), None);
 
-        let retrieved_struct = storage.read(key3).expect("Failed to retrieve struct");
+        let retrieved_struct = storage
+            .read(key3)
+            .unwrap()
+            .expect("Failed to retrieve struct");
         let deserialized_struct: CustomStruct = bincode::deserialize(retrieved_struct.as_slice())
             .expect("Failed to deserialize struct");
         assert_eq!(deserialized_struct, struct_payload2);

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -86,7 +86,7 @@ async fn concurrent_slow_streamed_write_test() {
     // Validate all writes
     for (key, _, expected_byte) in test_cases {
         let expected_data = vec![expected_byte; payload_size];
-        let retrieved = storage.read(key).unwrap();
+        let retrieved = storage.read(key).unwrap().unwrap();
 
         let all_values_match = retrieved.as_slice() == expected_data.as_slice();
         let length_match = retrieved.len() == expected_data.len();
@@ -150,7 +150,7 @@ async fn concurrent_write_test() {
             let key = format!("thread{}_key{}", thread_id, i).into_bytes();
             let value = format!("thread{}_value{}", thread_id, i).into_bytes();
 
-            let stored_value = storage.read(&key);
+            let stored_value = storage.read(&key).unwrap();
             eprintln!(
                 "[Main] Verifying {} -> {:?} (Found: {:?})",
                 String::from_utf8_lossy(&key),
@@ -191,7 +191,7 @@ async fn interleaved_read_write_test() {
         // Step 5: Wait for Thread B to write before reading the updated value
         notify_b_clone.notified().await;
 
-        let result = storage_clone_a.read(key);
+        let result = storage_clone_a.read(key).unwrap();
         eprintln!("[Thread A] Read updated value: {:?}", result.as_slice());
         assert_eq!(result.as_deref(), Some(b"value_from_B".as_ref()));
     });
@@ -206,7 +206,7 @@ async fn interleaved_read_write_test() {
         // Step 3: Wait for Thread A to write before reading
         notify_a_clone.notified().await;
 
-        let result = storage_clone_b.read(key);
+        let result = storage_clone_b.read(key).unwrap();
         eprintln!("[Thread B] Read initial value: {:?}", result);
         assert_eq!(result.as_deref(), Some(b"value_from_A1".as_ref()));
 
@@ -226,7 +226,7 @@ async fn interleaved_read_write_test() {
     res_b.unwrap();
 
     // Final Check: Ensure storage contains the latest value
-    let final_value = storage.read(b"shared_key");
+    let final_value = storage.read(b"shared_key").unwrap();
     eprintln!("[Main] FINAL VALUE: {:?}", final_value);
     assert_eq!(final_value.as_deref(), Some(b"value_from_B".as_ref()));
 }

--- a/tests/integrity_tests.rs
+++ b/tests/integrity_tests.rs
@@ -29,7 +29,7 @@ mod tests {
         storage.write(key, payload).expect("Failed to write entry");
 
         // Retrieve the entry handle
-        let entry_handle = storage.read(key).expect("Failed to read entry");
+        let entry_handle = storage.read(key).unwrap().expect("Failed to read entry");
 
         // Ensure checksum validation passes
         assert!(
@@ -68,7 +68,10 @@ mod tests {
             DataStore::open(&file_path).expect("Failed to reopen storage after corruption");
 
         // Attempt to read the corrupted entry
-        let corrupted_entry = storage.read(key).expect("Failed to read corrupted entry");
+        let corrupted_entry = storage
+            .read(key)
+            .unwrap()
+            .expect("Failed to read corrupted entry");
 
         assert!(
             !corrupted_entry.is_valid_checksum(),
@@ -100,9 +103,13 @@ mod tests {
             .expect("Failed to write stream entry");
 
         // Read both entries
-        let entry1 = storage.read(key1).expect("Failed to read entry from write");
+        let entry1 = storage
+            .read(key1)
+            .unwrap()
+            .expect("Failed to read entry from write");
         let entry2 = storage
             .read(key2)
+            .unwrap()
             .expect("Failed to read entry from write_stream");
 
         // Ensure checksums match
@@ -118,7 +125,10 @@ mod tests {
             .write(key3, different_payload)
             .expect("Failed to write different entry");
 
-        let entry3 = storage.read(key3).expect("Failed to read different entry");
+        let entry3 = storage
+            .read(key3)
+            .unwrap()
+            .expect("Failed to read different entry");
 
         // Ensure checksum is different for different content
         assert_ne!(

--- a/tests/mmap_and_zero_copy_tests.rs
+++ b/tests/mmap_and_zero_copy_tests.rs
@@ -27,7 +27,7 @@ mod tests {
         storage.write(key, payload).expect("Failed to write entry");
 
         // Retrieve the entry handle
-        let entry_handle = storage.read(key).expect("Failed to read entry");
+        let entry_handle = storage.read(key).unwrap().expect("Failed to read entry");
 
         // Clone the entry handle
         let cloned_entry = entry_handle.clone_arc();
@@ -71,7 +71,7 @@ mod tests {
         storage.write(key, payload).expect("Failed to write entry");
 
         // Retrieve the entry handle
-        let entry_handle = storage.read(key).expect("Failed to read entry");
+        let entry_handle = storage.read(key).unwrap().expect("Failed to read entry");
 
         // Clone the entry handle
         let cloned_entry = entry_handle.clone_arc();
@@ -123,7 +123,7 @@ mod tests {
         storage.write(key, payload).expect("Failed to write entry");
 
         // Retrieve the entry handle
-        let entry_handle = storage.read(key).expect("Failed to read entry");
+        let entry_handle = storage.read(key).unwrap().expect("Failed to read entry");
 
         // Get direct access to mmap for testing
         let mmap_arc = storage.get_mmap_arc_for_testing(); // Get Arc<Mmap>
@@ -158,7 +158,10 @@ mod tests {
         );
 
         // Ensure data integrity
-        let read_back = storage.read(key).expect("Entry should still be readable");
+        let read_back = storage
+            .read(key)
+            .unwrap()
+            .expect("Entry should still be readable");
         assert_eq!(
             read_back.as_slice(),
             payload,

--- a/tests/namespace_hasher_tests.rs
+++ b/tests/namespace_hasher_tests.rs
@@ -141,9 +141,9 @@ mod tests {
             .expect("Failed to write ns3 data");
 
         // Read back and verify
-        let read_ns1 = storage.read(&key_ns1).expect("Missing ns1 entry");
-        let read_ns2 = storage.read(&key_ns2).expect("Missing ns2 entry");
-        let read_ns3 = storage.read(&key_ns3).expect("Missing ns3 entry");
+        let read_ns1 = storage.read(&key_ns1).unwrap().expect("Missing ns1 entry");
+        let read_ns2 = storage.read(&key_ns2).unwrap().expect("Missing ns2 entry");
+        let read_ns3 = storage.read(&key_ns3).unwrap().expect("Missing ns3 entry");
 
         assert_eq!(read_ns1.as_slice(), payload_ns1);
         assert_eq!(read_ns2.as_slice(), payload_ns2);

--- a/tests/persistence_tests.rs
+++ b/tests/persistence_tests.rs
@@ -40,7 +40,7 @@ mod tests {
                 (b"key2", &b"Persistent Entry 2 ...."[..]),
                 (b"key3", &b"Persistent Entry 3 ......"[..]),
             ] {
-                let retrieved = storage.read(key);
+                let retrieved = storage.read(key).unwrap();
                 assert!(
                     retrieved.is_some(),
                     "Entry should be found after reopening, but got None"
@@ -92,12 +92,12 @@ mod tests {
             let storage = DataStore::open(&path).expect("Failed to reopen storage");
 
             assert_eq!(
-                storage.read(b"key1").as_deref(),
+                storage.read(b"key1").unwrap().as_deref(),
                 Some(b"Updated Value 1".as_slice()),
                 "Key1 should contain the updated value"
             );
             assert_eq!(
-                storage.read(b"key2").as_deref(),
+                storage.read(b"key2").unwrap().as_deref(),
                 Some(b"Updated Value 2".as_slice()),
                 "Key2 should contain the updated value"
             );
@@ -173,7 +173,7 @@ mod tests {
                 );
 
                 // Verify recovery worked
-                let recovered = storage.read(b"key1");
+                let recovered = storage.read(b"key1").unwrap();
                 assert!(
                     recovered.is_some(),
                     "Expected to recover at least one valid entry"
@@ -189,7 +189,7 @@ mod tests {
                     .expect("Failed to append entry after recovery");
 
                 // Verify new data
-                let retrieved = storage.read(new_key);
+                let retrieved = storage.read(new_key).unwrap();
                 assert!(
                     retrieved.is_some(),
                     "Failed to retrieve newly written entry after recovery"
@@ -205,10 +205,13 @@ mod tests {
             {
                 let storage = DataStore::open(&path).expect("Failed to recover storage");
 
-                assert_eq!(storage.read(b"key1").unwrap().as_slice(), b"Valid Entry");
+                assert_eq!(
+                    storage.read(b"key1").unwrap().unwrap().as_slice(),
+                    b"Valid Entry"
+                );
 
                 assert_eq!(
-                    storage.read(b"new_key").unwrap().as_slice(),
+                    storage.read(b"new_key").unwrap().unwrap().as_slice(),
                     b"New Data After Recovery"
                 );
             }

--- a/tests/storage_operation_tests.rs
+++ b/tests/storage_operation_tests.rs
@@ -35,7 +35,10 @@ mod tests {
             .expect("Failed to copy entry");
 
         // Step 3: Ensure the original entry still exists in the source
-        let original_entry = source_storage.read(key).expect("Source entry should exist");
+        let original_entry = source_storage
+            .read(key)
+            .unwrap()
+            .expect("Source entry should exist");
         assert_eq!(
             original_entry.as_slice(),
             payload,
@@ -45,6 +48,7 @@ mod tests {
         // Step 4: Ensure the copied entry exists in the target
         let copied_entry = target_storage
             .read(key)
+            .unwrap()
             .expect("Copied entry should exist in target");
         assert_eq!(
             copied_entry.as_slice(),
@@ -115,13 +119,14 @@ mod tests {
 
         // Step 3: Ensure the original entry no longer exists in the source
         assert!(
-            source_storage.read(key).is_none(),
+            source_storage.read(key).unwrap().is_none(),
             "Moved entry should no longer exist in source"
         );
 
         // Step 4: Ensure the moved entry exists in the target
         let moved_entry = target_storage
             .read(key)
+            .unwrap()
             .expect("Moved entry should exist in target");
         assert_eq!(
             moved_entry.as_slice(),
@@ -168,8 +173,14 @@ mod tests {
             .expect("Failed to append entry");
 
         // Verify initial entries exist
-        assert_eq!(storage.read(key1).as_deref(), Some(initial_payload1));
-        assert_eq!(storage.read(key2).as_deref(), Some(initial_payload2));
+        assert_eq!(
+            storage.read(key1).unwrap().as_deref(),
+            Some(initial_payload1)
+        );
+        assert_eq!(
+            storage.read(key2).unwrap().as_deref(),
+            Some(initial_payload2)
+        );
 
         // Update entries
         storage
@@ -180,8 +191,14 @@ mod tests {
             .expect("Failed to update entry");
 
         // Verify updates were applied correctly
-        assert_eq!(storage.read(key1).as_deref(), Some(updated_payload1));
-        assert_eq!(storage.read(key2).as_deref(), Some(updated_payload2));
+        assert_eq!(
+            storage.read(key1).unwrap().as_deref(),
+            Some(updated_payload1)
+        );
+        assert_eq!(
+            storage.read(key2).unwrap().as_deref(),
+            Some(updated_payload2)
+        );
 
         let count_before_delete = storage.count().unwrap();
 
@@ -200,7 +217,7 @@ mod tests {
 
         // Verify key1 is no longer retrievable
         assert!(
-            storage.read(key1).is_none(),
+            storage.read(key1).unwrap().is_none(),
             "Deleted key1 should not be retrievable"
         );
 
@@ -220,7 +237,7 @@ mod tests {
         }
 
         assert_eq!(
-            storage.read(b"key2").unwrap().as_slice(),
+            storage.read(b"key2").unwrap().unwrap().as_slice(),
             updated_payload2,
             "`key2` does not match updated payload"
         );
@@ -245,7 +262,10 @@ mod tests {
             .expect("Failed to rename entry");
 
         // Step 3: Ensure the new key exists and has the same data
-        let renamed_entry = storage.read(new_key).expect("Renamed entry should exist");
+        let renamed_entry = storage
+            .read(new_key)
+            .unwrap()
+            .expect("Renamed entry should exist");
         assert_eq!(
             renamed_entry.as_slice(),
             payload,
@@ -254,7 +274,7 @@ mod tests {
 
         // Step 4: Ensure the old key no longer exists
         assert!(
-            storage.read(old_key).is_none(),
+            storage.read(old_key).unwrap().is_none(),
             "Old key should no longer exist after renaming"
         );
     }
@@ -286,7 +306,10 @@ mod tests {
         );
 
         // Step 4: Ensure the original entry still exists
-        let existing_entry = storage.read(key).expect("Entry should still exist");
+        let existing_entry = storage
+            .read(key)
+            .unwrap()
+            .expect("Entry should still exist");
         assert_eq!(
             existing_entry.as_slice(),
             payload,
@@ -328,6 +351,7 @@ mod tests {
         // Step 5: Extract the nested storage from storage2
         let extracted_storage_bytes = storage2
             .read(nested_key)
+            .unwrap()
             .expect("Failed to retrieve the nested storage")
             .as_slice()
             .to_vec();
@@ -344,6 +368,7 @@ mod tests {
         // Step 8: Read the original entry from the extracted storage
         let retrieved_entry = extracted_storage
             .read(key1)
+            .unwrap()
             .expect("Failed to retrieve original entry from extracted storage");
 
         // Step 9: Validate that the extracted storage's data is correct

--- a/tests/streaming_tests.rs
+++ b/tests/streaming_tests.rs
@@ -51,6 +51,7 @@ mod tests {
         // Retrieve the entry
         let retrieved_entry = storage
             .read(large_key)
+            .unwrap()
             .expect("Failed to retrieve large entry");
 
         // Create an EntryStream from the retrieved entry


### PR DESCRIPTION
This PR experiments with a footer-based indexer to potentially improve startup time performance.

This current implementation would actually increase compaction sizes given a lot of keys and not any significant amount of data deletions in the original file.