### PR TITLE
[warn: perf regression] Use `Bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,7 @@ version = "0.11.0-alpha"
 dependencies = [
  "async-trait",
  "bincode",
+ "bytes",
  "clap",
  "crc32fast",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ memmap2 = "0.9.5"
 dashmap = "6.1.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+bytes = "1.10.1"
 
 [dependencies.clap]
 version = "4.5.32"

--- a/benches/contention_benchmark.rs
+++ b/benches/contention_benchmark.rs
@@ -5,6 +5,7 @@
 //! Toggle your lock implementation with a feature flag, build profile
 //! setting or Cargo alias (e.g. `cargo bench --features parking_lot`).
 
+use bytes::Bytes;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main, measurement::WallTime};
 use futures::future::join_all;
 use rand::{Rng, rng};
@@ -54,7 +55,11 @@ fn contention_bench(c: &mut Criterion<WallTime>) {
                                     let key = format!("t{t}_{i}");
                                     // random payload prevents easy compression
                                     let payload: Vec<u8> = (0..len).map(|_| rng.random()).collect();
-                                    s.write(key.as_bytes(), &payload).unwrap();
+                                    s.write(
+                                        Bytes::copy_from_slice(key.as_bytes()),
+                                        Bytes::from(payload),
+                                    )
+                                    .unwrap();
                                 }
                             }));
                         }

--- a/src/storage_engine/digest/compute_hash.rs
+++ b/src/storage_engine/digest/compute_hash.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use xxhash_rust::xxh3::xxh3_64;
 
 /// Computes a 64-bit hash for the given key using XXH3.
@@ -22,8 +23,8 @@ use xxhash_rust::xxh3::xxh3_64;
 /// See `crate::storage_engine::DataStore::write_stream_with_key_hash` for implementation
 /// details.
 #[inline]
-pub fn compute_hash(key: &[u8]) -> u64 {
-    xxh3_64(key)
+pub fn compute_hash(key: Bytes) -> u64 {
+    xxh3_64(&key)
 }
 
 /// Computes XXH3 64-bit hashes for a batch of keys **in one call**.
@@ -61,7 +62,7 @@ pub fn compute_hash(key: &[u8]) -> u64 {
 /// assert_eq!(hashes[2], compute_hash(b"carol"));
 /// ```
 #[inline]
-pub fn compute_hash_batch(keys: &[&[u8]]) -> Vec<u64> {
+pub fn compute_hash_batch(keys: &[Bytes]) -> Vec<u64> {
     // TODO: Look into more efficient approaches that can work on a matrix of
     // keys without iterating over them.
 

--- a/src/storage_engine/key_indexer.rs
+++ b/src/storage_engine/key_indexer.rs
@@ -1,6 +1,7 @@
 use crate::storage_engine::EntryMetadata;
 use crate::storage_engine::constants::*;
 use crate::storage_engine::digest::{Xxh3BuildHasher, compute_hash};
+use bytes::Bytes;
 use memmap2::Mmap;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -66,7 +67,7 @@ impl KeyIndexer {
 
     /// Computes a tag directly from the raw key.
     #[inline]
-    pub fn tag_from_key(key: &[u8]) -> u16 {
+    pub fn tag_from_key(key: Bytes) -> u16 {
         Self::tag_from_hash(compute_hash(key))
     }
 

--- a/src/storage_engine/traits/reader.rs
+++ b/src/storage_engine/traits/reader.rs
@@ -1,4 +1,5 @@
 use crate::storage_engine::EntryMetadata;
+use bytes::Bytes;
 use std::io::Result;
 
 pub trait DataStoreReader {
@@ -18,7 +19,7 @@ pub trait DataStoreReader {
     /// - `Ok(true)`: Key exists and is active.  
     /// - `Ok(false)`: Key is absent or has been deleted.  
     /// - `Err(std::io::Error)`: On I/O failure.
-    fn exists(&self, key: &[u8]) -> Result<bool>;
+    fn exists(&self, key: Bytes) -> Result<bool>;
 
     /// Retrieves the most recent value associated with a given key.
     ///
@@ -35,7 +36,7 @@ pub trait DataStoreReader {
     ///
     /// # Notes:
     /// - The returned `EntryHandle` provides zero-copy access to the stored data.
-    fn read(&self, key: &[u8]) -> Result<Option<Self::EntryHandleType>>;
+    fn read(&self, key: Bytes) -> Result<Option<Self::EntryHandleType>>;
 
     /// Retrieves the last entry written to the file.
     ///
@@ -63,7 +64,7 @@ pub trait DataStoreReader {
     /// # Returns:
     /// - `Ok(results)`: `Vec<Option<EntryHandle>>` in key order.
     /// - `Err(std::io::Error)`: On I/O failure.
-    fn batch_read(&self, keys: &[&[u8]]) -> Result<Vec<Option<Self::EntryHandleType>>>;
+    fn batch_read(&self, keys: &[Bytes]) -> Result<Vec<Option<Self::EntryHandleType>>>;
 
     /// Retrieves metadata for a given key.
     ///
@@ -76,7 +77,7 @@ pub trait DataStoreReader {
     /// - `Ok(Some(metadata))`: Metadata if the key exists.
     /// - `Ok(None)`: If the key is absent.
     /// - `Err(std::io::Error)`: On I/O failure.
-    fn read_metadata(&self, key: &[u8]) -> Result<Option<EntryMetadata>>;
+    fn read_metadata(&self, key: Bytes) -> Result<Option<EntryMetadata>>;
 
     /// Counts **active** (non-deleted) key-value pairs in the storage.
     ///
@@ -118,7 +119,7 @@ pub trait AsyncDataStoreReader {
     /// - `Ok(true)`: Key exists and is active.  
     /// - `Ok(false)`: Key is absent or has been deleted.  
     /// - `Err(std::io::Error)`: On I/O failure.
-    async fn exists(&self, key: &[u8]) -> Result<bool>;
+    async fn exists(&self, key: Bytes) -> Result<bool>;
 
     /// Retrieves the most recent value associated with a given key.
     ///
@@ -135,7 +136,7 @@ pub trait AsyncDataStoreReader {
     ///
     /// # Notes:
     /// - The returned `EntryHandle` provides zero-copy access to the stored data.
-    async fn read(&self, key: &[u8]) -> Result<Option<Self::EntryHandleType>>;
+    async fn read(&self, key: Bytes) -> Result<Option<Self::EntryHandleType>>;
 
     /// Retrieves the last entry written to the file.
     ///
@@ -163,7 +164,7 @@ pub trait AsyncDataStoreReader {
     /// # Returns:
     /// - `Ok(results)`: `Vec<Option<EntryHandle>>` in key order.
     /// - `Err(std::io::Error)`: On I/O failure.
-    async fn batch_read(&self, keys: &[&[u8]]) -> Result<Vec<Option<Self::EntryHandleType>>>;
+    async fn batch_read(&self, keys: &[Bytes]) -> Result<Vec<Option<Self::EntryHandleType>>>;
 
     /// Retrieves metadata for a given key.
     ///
@@ -176,7 +177,7 @@ pub trait AsyncDataStoreReader {
     /// - `Ok(Some(metadata))`: Metadata if the key exists.
     /// - `Ok(None)`: If the key is absent.
     /// - `Err(std::io::Error)`: On I/O failure.
-    async fn read_metadata(&self, key: &[u8]) -> Result<Option<EntryMetadata>>;
+    async fn read_metadata(&self, key: Bytes) -> Result<Option<EntryMetadata>>;
 
     /// Counts **active** (non-deleted) key-value pairs in the storage.
     ///

--- a/src/utils/namespace_hasher.rs
+++ b/src/utils/namespace_hasher.rs
@@ -1,4 +1,5 @@
 use crate::storage_engine::digest::compute_hash;
+use bytes::Bytes;
 
 /// A utility struct for namespacing keys using XXH3 hashing.
 ///
@@ -30,7 +31,7 @@ impl NamespaceHasher {
     /// # Returns
     /// - A `NamespaceHasher` instance with a precomputed prefix hash.
     #[inline]
-    pub fn new(prefix: &[u8]) -> Self {
+    pub fn new(prefix: Bytes) -> Self {
         Self {
             prefix: compute_hash(prefix),
         }
@@ -53,7 +54,7 @@ impl NamespaceHasher {
     /// # Returns
     /// - A `Vec<u8>` containing the **16-byte** namespaced key (`8-byte prefix hash + 8-byte key hash`).
     #[inline]
-    pub fn namespace(&self, key: &[u8]) -> Vec<u8> {
+    pub fn namespace(&self, key: Bytes) -> Vec<u8> {
         let key_hash = compute_hash(key);
 
         // Combine both hashes into a 16-byte buffer

--- a/tests/streaming_tests.rs
+++ b/tests/streaming_tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
 
+    use bytes::Bytes;
     use simd_r_drive::{
         DataStore, compute_checksum,
         traits::{DataStoreReader, DataStoreWriter},
@@ -92,7 +93,7 @@ mod tests {
     fn test_write_stream_null_byte_fails() {
         let (_dir, storage) = create_temp_storage();
 
-        let key = b"test_key";
+        let key = Bytes::copy_from_slice(b"test_key");
         let mut payload = b"\x00".as_ref(); // Hardcoded null-byte
 
         let result = storage.write_stream(key, &mut payload);


### PR DESCRIPTION
Conclusion:  Using `bytes` for hot paths seems to slow down quite measurably...


## Benchmark Comparison: Bytes vs &[u8] / Vec<u8>

### writers_vs_lock (criterion)

| Test           | With Bytes        | With &[u8] / Vec<u8> | Change              |
|----------------|------------------|----------------------|---------------------|
| 128 bytes      | 110–113 ms       | 108–110 ms           | −0.16% to −2.21%    |
| 4096 bytes     | 221–227 ms       | 217–221 ms           | −0.56% to −3.83%    |
| 65536 bytes    | 779–790 ms       | 775–784 ms           | −0.53% to −1.42%    |

### storage_benchmark.rs (custom)

| Operation         | With Bytes       | With &[u8] / Vec<u8> | Change           |
|-------------------|------------------|----------------------|------------------|
| Writes            | 2,042,067.8/s    | 3,375,536.2/s        | +65.3%           |
| Sequential reads  | 10,109,521.4/s   | 10,125,548.8/s       | ~0%              |
| Random reads      | 2,217,144.9/s    | 2,430,574.9/s        | +9.6%            |
| Batch reads       | 2,567,538.4/s    | 4,808,404.5/s        | +87.3%           |

